### PR TITLE
Change project/package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MyST-Parser
 
-[![Build Status](https://travis-ci.org/ExecutableBookProject/MyST-Parser.svg?branch=master)](https://travis-ci.org/ExecutableBookProject/MyST-Parser)
-[![Coverage Status](https://coveralls.io/repos/github/ExecutableBookProject/MyST-Parser/badge.svg?branch=improvements)](https://coveralls.io/github/ExecutableBookProject/MyST-Parser?branch=improvements)
+[![Build Status](https://travis-ci.org/ExecutableBookProject/MyST-Parser.svg?branch=develop)](https://travis-ci.org/ExecutableBookProject/MyST-Parser)
+[![Coverage Status](https://coveralls.io/repos/github/ExecutableBookProject/MyST-Parser/badge.svg?branch=develop)](https://coveralls.io/github/ExecutableBookProject/MyST-Parser?branch=develop)
 [![Documentation Status](https://readthedocs.org/projects/myst-parser/badge/?version=latest)](https://myst-parser.readthedocs.io/en/latest/?badge=latest)
 
 An extended commonmark compliant parser, with bridges to docutils & sphinx.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# myst_parser
+# MyST-Parser
 
-[![Build Status](https://travis-ci.org/ExecutableBookProject/myst_parser.svg?branch=master)](https://travis-ci.org/ExecutableBookProject/myst_parser)
-[![Coverage Status](https://coveralls.io/repos/github/ExecutableBookProject/myst_parser/badge.svg?branch=improvements)](https://coveralls.io/github/ExecutableBookProject/myst_parser?branch=improvements)
+[![Build Status](https://travis-ci.org/ExecutableBookProject/MyST-Parser.svg?branch=master)](https://travis-ci.org/ExecutableBookProject/MyST-Parser)
+[![Coverage Status](https://coveralls.io/repos/github/ExecutableBookProject/MyST-Parser/badge.svg?branch=improvements)](https://coveralls.io/github/ExecutableBookProject/MyST-Parser?branch=improvements)
 [![Documentation Status](https://readthedocs.org/projects/myst-parser/badge/?version=latest)](https://myst-parser.readthedocs.io/en/latest/?badge=latest)
 
 An extended commonmark compliant parser, with bridges to docutils & sphinx.
 
 ## Usage
 
-```console
-pip install -e git+https://github.com/ExecutableBookProject/myst_parser.git#egg=myst_parser[sphinx]
+```bash
+pip install -e "git+https://github.com/ExecutableBookProject/MyST-Parser.git#egg=myst-parser[sphinx]"
 ```
 
 Or for package development:
 
 ```bash
-git clone https://github.com/ExecutableBookProject/myst_parser
-cd myst_parser
+git clone https://github.com/ExecutableBookProject/MyST-Parser
+cd MyST-Parser
 git checkout develop
 pip install -e .[sphinx,code_style,testing,rtd]
 ```
@@ -24,7 +24,7 @@ pip install -e .[sphinx,code_style,testing,rtd]
 Note, this parser currently requires the [ExecutableBookProject/mistletoe](https://github.com/ExecutableBookProject/mistletoe)
 fork of mistletoe (included in the above installation).
 
-To use the Myst parser in sphinx, simply add: `extensions = ["myst_parser"]` to your `conf.py`.
+To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to your `conf.py`.
 
 ## Parsed Token Classes
 
@@ -71,13 +71,13 @@ Code style is tested using [flake8](http://flake8.pycqa.org),
 with the configuration set in `.flake8`,
 and code formatted with [black](https://github.com/ambv/black).
 
-Installing with `myst_parser[code_style]` makes the [pre-commit](https://pre-commit.com/)
+Installing with `myst-parser[code_style]` makes the [pre-commit](https://pre-commit.com/)
 package available, which will ensure this style is met before commits are submitted, by reformatting the code
 and testing for lint errors.
 It can be setup by:
 
 ```shell
->> cd myst_parser
+>> cd MyST-Parser
 >> pre-commit install
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Myst Parser"
+project = "MyST Parser"
 copyright = "2020, Executable Book Project"
 author = "Executable Book Project"
 

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -6,13 +6,13 @@ Code style is tested using [flake8](http://flake8.pycqa.org),
 with the configuration set in `.flake8`,
 and code formatted with [black](https://github.com/ambv/black).
 
-Installing with `myst_parser[code_style]` makes the [pre-commit](https://pre-commit.com/)
+Installing with `myst-parser[code_style]` makes the [pre-commit](https://pre-commit.com/)
 package available, which will ensure this style is met before commits are submitted, by reformatting the code
 and testing for lint errors.
 It can be setup by:
 
 ```shell
->> cd myst_parser
+>> cd MyST-Parser
 >> pre-commit install
 ```
 

--- a/docs/develop/test_infrastructure.md
+++ b/docs/develop/test_infrastructure.md
@@ -13,5 +13,5 @@ The tests are ordered in a hierarchical fashion:
 1. In `tests/test_syntax` are tests that check that the source text is being correctly converted to the Markdown ([mistletoe](https://github.com/miyuchina/mistletoe)) AST.
 2. In `tests/test_commonmark` the [CommonMark](https://github.com/commonmark/CommonMark.git) test set is run; to check that the parser is complying with the CommonMark specification.
 3. In `tests/test_renderers` are tests that check that the Markdown AST is being correctly converted to the docutils/sphinx AST. This includes testing that roles and directives are correctly parsed and run.
-4. In `tests/test_sphinx` are tests that check that minimal sphinx project builds are running correctly, to convert myst markdown files to HTML.
-5. In `.circleci` the package documentation (written in myst format) is built and tested for build errors/warnings.
+4. In `tests/test_sphinx` are tests that check that minimal sphinx project builds are running correctly, to convert MyST markdown files to HTML.
+5. In `.circleci` the package documentation (written in MyST format) is built and tested for build errors/warnings.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,7 +1,7 @@
 # Example documents
 
 The following pages are examples meant to highlight the functionality of
-Myst documents.
+MyST documents.
 
 ```{toctree}
 ---

--- a/docs/using/index.md
+++ b/docs/using/index.md
@@ -1,7 +1,7 @@
 # Using MyST
 
 The following pages are examples meant to highlight the functionality of
-Myst documents.
+MyST documents.
 
 ```{toctree}
 install.md

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -8,17 +8,19 @@ Installing the MyST parser provides access to two tools:
 To install the MyST parser, run the following:
 
 ```bash
-pip install -e "git+https://github.com/ExecutableBookProject/myst_parser.git#egg=myst_parser[sphinx]"
+pip install -e "git+https://github.com/ExecutableBookProject/MyST-Parser.git#egg=myst-parser[sphinx]"
 ```
 
 Or for package development:
 
 ```bash
-git clone https://github.com/ExecutableBookProject/myst_parser
-cd myst_parser
+git clone https://github.com/ExecutableBookProject/MyST-Parser
+cd MyST-Parser
 git checkout develop
 pip install -e .[sphinx,code_style,testing,rtd]
 ```
 
 This should install the myst fork of mistletoe, along with the Sphinx parser
 that is included in the "extensions" configuration of this site.
+
+To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to your `conf.py`.

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -1,13 +1,13 @@
 (example_syntax)=
 
-# Example syntax for myst
+# Example syntax for MyST
 
-As a base, Myst adheres to the [CommonMark specification](https://spec.commonmark.org/).
+As a base, MyST adheres to the [CommonMark specification](https://spec.commonmark.org/).
 For this, it uses the [Mistletoe project](https://github.com/miyuchina/mistletoe),
 which is a well-structured markdown parser for Python that is CommonMark-compliant
 and also extensible.
 
-Myst adds several new syntax options that extend its functionality to be used
+MyST adds several new syntax options that extend its functionality to be used
 with Sphinx, the documentation generation engine used extensively in the Python
 ecosystem. Sphinx uses reStructuredText by default, which is both more
 powerful than Markdown, and also (arguably) more complex to use.
@@ -96,7 +96,7 @@ defines "runnable cells". Here is the basic structure:
 ---
 header-rows: 1
 ---
-* - Myst
+* - MyST
   - reStructuredText
 * - ````markdown
     ```{directivename} arguments
@@ -276,7 +276,7 @@ role, use the following form:
 ---
 header-rows: 1
 ---
-* - Myst
+* - MyST
   - reStructuredText
 * - ````markdown
     {role-name}`role content`
@@ -327,14 +327,14 @@ Here is some extra markdown syntax which provides functionality in rST that does
 exist in CommonMark. In most cases, these are syntactic short-cuts to calling
 roles and directives. We'll cover some common ones below.
 
-This tale describes the rST and Myst equivalents:
+This tale describes the rST and MyST equivalents:
 
 ````{list-table}
 ---
 header-rows: 1
 ---
 * - Type
-  - Myst
+  - MyST
   - reStructuredText
 * - Math shortcuts
   - `$x^2$`

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 def setup(app):

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -14,7 +14,7 @@ class MystParser(parsers.Parser):
 
     # these specs are copied verbatim from the docutils RST parser
     settings_spec = (
-        "Myst Parser Options",
+        "MyST Parser Options",
         None,
         (
             (

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,17 @@
-"""myst_parser package setup."""
+"""myst-parser package setup."""
 from importlib import import_module
 
 from setuptools import find_packages, setup
 
 setup(
-    name="myst_parser",
+    name="myst-parser",
     version=import_module("myst_parser").__version__,
     description=(
         "An extended commonmark compliant parser, " "with bridges to docutils & sphinx."
     ),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/ExecutableBookProject/myst_parser",
+    url="https://github.com/ExecutableBookProject/MyST-Parser",
     author="Chris Sewell",
     author_email="chrisj_sewell@hotmail.com",
     license="MIT",


### PR DESCRIPTION
- The GitHub folder has been renamed from  `myst_parser` to `MyST-Parser`
- The package name has been changed from `myst_parser` to `myst-parser`
- Also changed doc references from Myst to MyST

Better sooner rather than later!
@choldgraf this will need to be changed in the MyST-NB setup
@rossbar @mmcky @jstac @akhmerov you are potential users that I can think of that this might affect.