### PR TITLE
fixing xref literal bug

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -590,7 +590,7 @@ class SphinxRenderer(DocutilsRenderer):
         if token.title:
             wrap_node["title"] = token.title
         self.current_node.append(wrap_node)
-        text_node = nodes.TextElement("", "", classes=["xref", "any"])
+        text_node = nodes.literal("", "", classes=["xref", "any"])
         wrap_node.append(text_node)
         with self.current_node_context(text_node):
             self.render_children(token)

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -316,6 +316,19 @@ def test_link_reference_no_key(renderer):
     )
 
 
+def test_link_reference_no_exist(renderer):
+    renderer.render(Document(["[name](foo)"]))
+    assert renderer.document.pformat() == dedent(
+        """\
+<document source="notset">
+    <paragraph>
+        <pending_xref refdomain="True" refexplicit="True" reftarget="foo" reftype="any" refwarn="True">
+            <literal classes="xref any">
+                name
+    """
+    )
+
+
 def test_block_quotes(renderer):
     renderer.render(
         Document(


### PR DESCRIPTION
This closes #89 , but doesn't improve the extra things that @chrisjsewell mentioned as "like to have"s for the xref functionality. For that, I've opened up a new issue: https://github.com/ExecutableBookProject/MyST-Parser/issues/91

This adds a test to make sure that cross-refs are correctly in there as literals until they get resolved. 