### PR TITLE
Add sphinxcontrib-sphinx test for missing reference

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ help:
 
 # raise warnings to errors
 html-strict:
-	@$(SPHINXBUILD) -b html -nW "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html -nW --keep-going "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 
 clean:
 	rm -r $(BUILDDIR)

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -7,4 +7,4 @@
 ```{bibliography} references2.bib
 ```
 
-abc
+lmd

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -2,7 +2,7 @@
 
 {cite}`unknown`
 
-{cite}`md2-abc`
+
 
 ```{bibliography} references2.bib
 :labelprefix: md2

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -2,7 +2,7 @@
 
 {cite}`unknown`
 
-{cite}`abc`
+
 
 ```{bibliography} references2.bib
 ```

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -4,3 +4,5 @@
 
 ```bibliography references2.bib
 ```
+
+abc

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -4,7 +4,7 @@
 
 {cite}`abc`
 
-```bibliography references2.bib
+```{bibliography} references2.bib
 ```
 
 abc

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -8,5 +8,3 @@
 :labelprefix: md2
 :keyprefix: md2-
 ```
-
-lmd

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -2,6 +2,8 @@
 
 {cite}`unknown`
 
+{cite}`abc`
+
 ```bibliography references2.bib
 ```
 

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -1,0 +1,6 @@
+# Test MyST
+
+{cite}`unknown`
+
+```bibliography references2.bib
+```

--- a/docs/bibtex_test/example_md.md
+++ b/docs/bibtex_test/example_md.md
@@ -2,9 +2,11 @@
 
 {cite}`unknown`
 
-
+{cite}`md2-abc`
 
 ```{bibliography} references2.bib
+:labelprefix: md2
+:keyprefix: md2-
 ```
 
 lmd

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -1,0 +1,6 @@
+Test rST
+--------
+
+:cite:`unknown`
+
+.. bibliography:: references2.bib

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -3,6 +3,8 @@ Test rST
 
 :cite:`unknown`
 
+:cite:`abc`
+
 .. bibliography:: references2.bib
 
 xyz

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -8,5 +8,3 @@ Test rST
 .. bibliography:: references3.bib
     :labelprefix: rst2
     :keyprefix: rst2-
-
-ghk

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -3,8 +3,10 @@ Test rST
 
 :cite:`unknown`
 
-
+:cite:`rst2-xyz`
 
 .. bibliography:: references3.bib
+    :labelprefix: rst2
+    :keyprefix: rst2-
 
 ghk

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -3,7 +3,7 @@ Test rST
 
 :cite:`unknown`
 
-:cite:`xyz`
+
 
 .. bibliography:: references3.bib
 

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -3,8 +3,8 @@ Test rST
 
 :cite:`unknown`
 
-:cite:`abc`
+:cite:`xyz`
 
-.. bibliography:: references2.bib
+.. bibliography:: references3.bib
 
 xyz

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -3,7 +3,7 @@ Test rST
 
 :cite:`unknown`
 
-:cite:`rst2-xyz`
+
 
 .. bibliography:: references3.bib
     :labelprefix: rst2

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -7,4 +7,4 @@ Test rST
 
 .. bibliography:: references3.bib
 
-xyz
+ghk

--- a/docs/bibtex_test/example_rst.rst
+++ b/docs/bibtex_test/example_rst.rst
@@ -4,3 +4,5 @@ Test rST
 :cite:`unknown`
 
 .. bibliography:: references2.bib
+
+xyz

--- a/docs/bibtex_test/index.md
+++ b/docs/bibtex_test/index.md
@@ -1,0 +1,6 @@
+# Test bibtex with missing ref
+
+```{toctree}
+example_rst.rst
+example_md.md
+```

--- a/docs/bibtex_test/references2.bib
+++ b/docs/bibtex_test/references2.bib
@@ -1,0 +1,12 @@
+###
+Single example from the QuantEcon Bib
+###
+@article{benhabib2018skewed,
+    title={Skewed wealth distributions: Theory and empirics},
+    author={Benhabib, Jess and Bisin, Alberto},
+    journal={Journal of Economic Literature},
+    volume={56},
+    number={4},
+    pages={1261--91},
+    year={2018}
+}

--- a/docs/bibtex_test/references2.bib
+++ b/docs/bibtex_test/references2.bib
@@ -1,7 +1,7 @@
 ###
 Single example from the QuantEcon Bib
 ###
-@article{benhabib2018skewed,
+@article{abc,
     title={Skewed wealth distributions: Theory and empirics},
     author={Benhabib, Jess and Bisin, Alberto},
     journal={Journal of Economic Literature},

--- a/docs/bibtex_test/references3.bib
+++ b/docs/bibtex_test/references3.bib
@@ -1,8 +1,8 @@
 ###
 Single example from the QuantEcon Bib
 ###
-@article{abc,
-    title={a Skewed wealth distributions: Theory and empirics},
+@article{xyz,
+    title={b Skewed wealth distributions: Theory and empirics},
     author={Benhabib, Jess and Bisin, Alberto},
     journal={Journal of Economic Literature},
     volume={56},

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = "pandas_sphinx_theme"
-# html_logo = "_static/logo.png"
+html_theme = "pandas_sphinx_theme"
+html_logo = "_static/logo.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pandas_sphinx_theme"
-html_logo = "_static/logo.png"
+# html_theme = "pandas_sphinx_theme"
+# html_logo = "_static/logo.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,5 +54,6 @@ caption: Contents
 using/index.md
 examples/index.md
 develop/index.md
+bibtex_test/index.md
 package_api.md
 ```

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             "pytest-cov",
             "pytest-regressions",
             "beautifulsoup4",
+            "sphinxcontrib-bibtex~=1.0",
         ],
         "rtd": [
             "sphinxcontrib-bibtex",

--- a/tests/test_sphinx/sourcedirs/bibtex_norefs/conf.py
+++ b/tests/test_sphinx/sourcedirs/bibtex_norefs/conf.py
@@ -1,0 +1,2 @@
+extensions = ["myst_parser", "sphinxcontrib.bibtex"]
+exclude_patterns = ["_build"]

--- a/tests/test_sphinx/sourcedirs/bibtex_norefs/index.md
+++ b/tests/test_sphinx/sourcedirs/bibtex_norefs/index.md
@@ -1,0 +1,4 @@
+missing ref {cite}`abc`
+
+```{bibliography} references.bib
+```

--- a/tests/test_sphinx/sourcedirs/bibtex_norefs/references.bib
+++ b/tests/test_sphinx/sourcedirs/bibtex_norefs/references.bib
@@ -1,0 +1,12 @@
+###
+Single example from the QuantEcon Bib
+###
+@article{benhabib2018skewed,
+    title={Skewed wealth distributions: Theory and empirics},
+    author={Benhabib, Jess and Bisin, Alberto},
+    journal={Journal of Economic Literature},
+    volume={56},
+    number={4},
+    pages={1261--91},
+    year={2018}
+}

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -44,3 +44,25 @@ def test_includes(
 
     get_sphinx_app_doctree(app, filename="index.doctree", regress=True)
     get_sphinx_app_output(app, filename="index.html", regress_html=True)
+
+
+@pytest.mark.sphinx(
+    buildername="html", srcdir=os.path.join(SOURCE_DIR, "bibtex_norefs"), freshenv=True
+)
+def test_bibtex_norefs(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    get_sphinx_app_output,
+    remove_sphinx_builds,
+):
+    """Test of spinxcontrib-bibtex extension."""
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = warning.getvalue().strip()
+    assert "citation not found: abc" in warnings
+
+    get_sphinx_app_doctree(app, filename="index.doctree", regress=True)
+    get_sphinx_app_output(app, filename="index.html", regress_html=True)

--- a/tests/test_sphinx/test_sphinx_builds/test_bibtex_norefs.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_bibtex_norefs.html
@@ -1,0 +1,14 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <p>
+    missing ref
+    <span class="bibtex" id="id1">
+     [abc]
+    </span>
+   </p>
+   <p id="bibtex-bibliography-index-0">
+   </p>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_bibtex_norefs.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_bibtex_norefs.xml
@@ -1,0 +1,7 @@
+<document source="index.md">
+    <paragraph>
+        missing ref 
+        <pending_xref classes="bibtex" ids="id1" refdomain="citation" reftarget="abc" reftype="ref" refwarn="True" support_smartquotes="False">
+            <inline>
+                [abc]
+    <paragraph ids="bibtex-bibliography-index-0">


### PR DESCRIPTION
@mtiley I have tried to replicate your issue in #95, but I do not find this issue.

Can you try using this fork, to run:

```console
$ pytest tests/test_sphinx/test_sphinx_builds.py::test_bibtex_norefs
```

and let me know if it passes. If it does pass, then maybe try to have a look at the test I have written, and see if you can alter it to fail with your issue.
You may want to take a look at https://myst-parser.readthedocs.io/en/latest/develop/test_infrastructure.html#test-tools re: pytest-regressions.