### PR TITLE
Propogate block line ranges to span elements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,6 +118,7 @@ nitpick_ignore = [
     ("py:class", "mistletoe.block_token.Footnote"),
     ("py:class", "mistletoe.block_token.Paragraph"),
     ("py:class", "mistletoe.block_token.ThematicBreak"),
+    ("py:class", "mistletoe.block_token.HTMLBlock"),
     ("py:class", "mistletoe.base_renderer.BaseRenderer"),
     ("py:class", "mistletoe.html_renderer.HTMLRenderer"),
     ("py:class", "mistletoe.span_token.SpanToken"),

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -25,6 +25,9 @@ Optionally you can run `black` and `flake8` separately:
 
 Editors like VS Code also have automatic code reformat utilities, which can adhere to this standard.
 
+All functions and class methods should be annotated with types and include a docstring. The prefered docstring format is outlined in `MyST-Parser/docstring.fmt.mustache` and can be used automatically with the
+[autodocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) VS Code extension.
+
 ## Testing
 
 For code tests:

--- a/docs/using/use_api.md
+++ b/docs/using/use_api.md
@@ -35,7 +35,7 @@ Here's some *text*
 
 1. a list
 
-> a quote""")
+> a *quote*""")
 root
 ```
 
@@ -64,6 +64,34 @@ list_token.__dict__
 
 ```python
 {'children': [MyST.ListItem(children=1)], 'loose': False, 'start': 1}
+```
+
+You can also recursively traverse the syntax tree, yielding `TraverseResult`s that contain the element, its parent and depth from the source token:
+
+```python
+from pprint import pprint
+from myst_parser import traverse
+tree = [
+    (t.parent.__class__.__name__, t.node.__class__.__name__, t.depth)
+    for t in traverse(root)
+]
+pprint(tree)
+```
+
+```python
+[('Document', 'Paragraph', 1),
+ ('Document', 'List', 1),
+ ('Document', 'Quote', 1),
+ ('Paragraph', 'RawText', 2),
+ ('Paragraph', 'Emphasis', 2),
+ ('List', 'ListItem', 2),
+ ('Quote', 'Paragraph', 2),
+ ('Emphasis', 'RawText', 3),
+ ('ListItem', 'Paragraph', 3),
+ ('Paragraph', 'RawText', 3),
+ ('Paragraph', 'Emphasis', 3),
+ ('Paragraph', 'RawText', 4),
+ ('Emphasis', 'RawText', 4)]
 ```
 
 ## AST Renderer

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,6 +1,6 @@
 from .utils import traverse  # noqa: F401
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,3 +1,5 @@
+from .utils import traverse  # noqa: F401
+
 __version__ = "0.2.0"
 
 

--- a/myst_parser/utils.py
+++ b/myst_parser/utils.py
@@ -1,4 +1,6 @@
+from collections import namedtuple
 import html
+from typing import Iterable
 from urllib.parse import quote
 
 
@@ -7,3 +9,32 @@ def escape_url(raw):
     Escape urls to prevent code injection craziness. (Hopefully.)
     """
     return html.escape(quote(html.unescape(raw), safe="/#:()*?=%@+,&"))
+
+
+TraverseResult = namedtuple("TraverseResult", ["node", "parent", "depth"])
+
+
+def traverse(
+    source, klass=None, depth=None, include_source=False
+) -> Iterable[TraverseResult]:
+    """Traverse the syntax tree, recursively yielding children.
+
+    :param source: The source syntax element
+    :param klass: filter children by a certain element class
+    :param depth: The depth to recurse into the tree
+    :param include_source: whether to first yield the source element
+
+    :yield: A container for an element, its parent and depth
+    """
+    current_depth = 0
+    if include_source:
+        yield TraverseResult(source, None, current_depth)
+    next_children = [(source, c) for c in getattr(source, "children", [])]
+    while next_children and (depth is None or current_depth > depth):
+        current_depth += 1
+        new_children = []
+        for parent, child in next_children:
+            if klass is None or issubclass(child, klass):
+                yield TraverseResult(child, parent, current_depth)
+            new_children.extend([(child, c) for c in getattr(child, "children", [])])
+        next_children = new_children

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -14,6 +14,8 @@ def render_token(
 ):
     render_func = renderer_mock.render_map[token_name]
     children = mock.MagicMock(spec=list) if children else None
+    if "range" not in kwargs:
+        kwargs["range"] = (0, 0)
     mock_token = mock.Mock(children=children, **kwargs)
     without_attrs = without_attrs or []
     for attr in without_attrs:

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 
 import pytest
 
-from myst_parser import text_to_tokens, block_tokens
+from myst_parser import text_to_tokens, block_tokens, traverse
 from myst_parser.ast_renderer import AstRenderer
 from myst_parser.block_tokens import Document
 
@@ -18,6 +18,33 @@ def test_render_tokens():
     root = text_to_tokens("abc")
     assert isinstance(root, Document)
     assert root.children, root.children
+
+
+def test_traverse(ast_renderer):
+    doc = Document(
+        dedent(
+            """\
+        a **b**
+
+        c [*d*](link)
+        """
+        )
+    )
+    tree = [
+        (t.node.__class__.__name__, t.parent.__class__.__name__, t.depth)
+        for t in traverse(doc)
+    ]
+    assert tree == [
+        ("Paragraph", "Document", 1),
+        ("Paragraph", "Document", 1),
+        ("RawText", "Paragraph", 2),
+        ("Strong", "Paragraph", 2),
+        ("RawText", "Paragraph", 2),
+        ("Link", "Paragraph", 2),
+        ("RawText", "Strong", 3),
+        ("Emphasis", "Link", 3),
+        ("RawText", "Emphasis", 4),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
@@ -2,9 +2,18 @@ children:
 - children:
   - children:
     - content: +
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: EscapeSequence
   - content: ++
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
@@ -3,6 +3,9 @@ children:
   - children:
     - children:
       - content: item
+        range:
+        - 1
+        - 1
         type: RawText
       range:
       - 1

--- a/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
@@ -3,6 +3,9 @@ children:
   - content: '+++
 
       '
+    range:
+    - 0
+    - 1
     type: RawText
   language: ''
   range:

--- a/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: a +++
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
@@ -2,9 +2,18 @@ children:
 - children:
   - children:
     - content: '%'
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: EscapeSequence
   - content: ' comment'
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
@@ -3,6 +3,9 @@ children:
   - children:
     - children:
       - content: item
+        range:
+        - 1
+        - 1
         type: RawText
       range:
       - 1

--- a/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
@@ -3,6 +3,9 @@ children:
   - content: '% comment
 
       '
+    range:
+    - 0
+    - 1
     type: RawText
   language: ''
   range:

--- a/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: a % comment
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: '[ref]'
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1
@@ -9,9 +12,18 @@ children:
 - children:
   - children:
     - content: '['
+      range:
+      - 3
+      - 3
       type: RawText
+    range:
+    - 3
+    - 3
     type: EscapeSequence
   - content: 'ref]: https://google.com "title"'
+    range:
+    - 3
+    - 3
     type: RawText
   range:
   - 3

--- a/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: ref
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: https://google.com
     title: title
     type: Link

--- a/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: ref
+      range:
+      - 3
+      - 3
       type: RawText
+    range:
+    - 3
+    - 3
     target: https://google.com
     title: title
     type: Link

--- a/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
@@ -3,8 +3,17 @@ children:
   - children:
     - children:
       - content: syntax
+        range:
+        - 1
+        - 1
         type: RawText
+      range:
+      - 1
+      - 1
       type: Emphasis
+    range:
+    - 1
+    - 1
     target: https://google.com
     title: title
     type: Link

--- a/tests/test_syntax/test_ast/test_math_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_math_basic_strings0_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: $a$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_contains_special_chars_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_math_contains_special_chars_strings1_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: $a`{_*-%$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_escaped_opening_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_math_escaped_opening_strings4_.yml
@@ -2,11 +2,23 @@ children:
 - children:
   - children:
     - content: $
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: EscapeSequence
   - content: 'a '
+    range:
+    - 1
+    - 1
     type: RawText
   - content: $b$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_external_emphasis_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_math_external_emphasis_strings7_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: $a$
+      range:
+      - 1
+      - 1
       type: Math
+    range:
+    - 1
+    - 1
     type: Emphasis
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_in_image_strings12_.yml
+++ b/tests/test_syntax/test_ast/test_math_in_image_strings12_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: $a$
+      range:
+      - 1
+      - 1
       type: Math
+    range:
+    - 1
+    - 1
     src: $b$
     title: ''
     type: Image

--- a/tests/test_syntax/test_ast/test_math_in_link_content_strings10_.yml
+++ b/tests/test_syntax/test_ast/test_math_in_link_content_strings10_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: $a$
+      range:
+      - 1
+      - 1
       type: Math
+    range:
+    - 1
+    - 1
     target: link
     title: ''
     type: Link

--- a/tests/test_syntax/test_ast/test_math_in_link_target_strings11_.yml
+++ b/tests/test_syntax/test_ast/test_math_in_link_target_strings11_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: a
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: $b$
     title: ''
     type: Link

--- a/tests/test_syntax/test_ast/test_math_internal_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_math_internal_emphasis_strings6_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: $*a*$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_issue_51_strings9_.yml
+++ b/tests/test_syntax/test_ast/test_math_issue_51_strings9_.yml
@@ -1,27 +1,60 @@
 children:
 - children:
   - content: 'Math can be called in-line with single '
+    range:
+    - 1
+    - 2
     type: RawText
   - children:
     - content: $
+      range:
+      - 1
+      - 2
       type: RawText
+    range:
+    - 1
+    - 2
     type: InlineCode
   - content: ' characters around math.'
+    range:
+    - 1
+    - 2
     type: RawText
   - content: ''
+    range:
+    - 1
+    - 2
     soft: true
     type: LineBreak
   - content: 'For example, '
+    range:
+    - 1
+    - 2
     type: RawText
   - children:
     - content: $x_{hey}=it+is^{math}$
+      range:
+      - 1
+      - 2
       type: RawText
+    range:
+    - 1
+    - 2
     type: InlineCode
   - content: ' renders '
+    range:
+    - 1
+    - 2
     type: RawText
   - content: $x_{hey}=it+is^{math}$
+    range:
+    - 1
+    - 2
     type: Math
   - content: .
+    range:
+    - 1
+    - 2
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_multiline_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_math_multiline_strings8_.yml
@@ -5,6 +5,9 @@ children:
       c
 
       b$$'
+    range:
+    - 1
+    - 3
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_multiple_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_math_multiple_strings3_.yml
@@ -1,10 +1,19 @@
 children:
 - children:
   - content: $a$
+    range:
+    - 1
+    - 1
     type: Math
   - content: ' '
+    range:
+    - 1
+    - 1
     type: RawText
   - content: $b$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_no_closing_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_math_no_closing_strings5_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: $a
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_math_preceding_special_chars_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_math_preceding_special_chars_strings2_.yml
@@ -1,8 +1,14 @@
 children:
 - children:
   - content: '{_*-%`'
+    range:
+    - 1
+    - 1
     type: RawText
   - content: $a$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
@@ -2,8 +2,14 @@ children:
 - children:
   - children:
     - content: some content
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
@@ -2,13 +2,28 @@ children:
 - children:
   - children:
     - content: '{'
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: EscapeSequence
   - content: name}
+    range:
+    - 1
+    - 1
     type: RawText
   - children:
     - content: some content
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: InlineCode
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: '{name}`some content`'
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: InlineCode
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
@@ -3,9 +3,18 @@ children:
   - children:
     - children:
       - content: content
+        range:
+        - 1
+        - 1
         type: RawText
       name: name
+      range:
+      - 1
+      - 1
       type: Role
+    range:
+    - 1
+    - 1
     type: Emphasis
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
@@ -1,6 +1,9 @@
 children:
 - children:
   - content: ${name}`some content`$
+    range:
+    - 1
+    - 1
     type: Math
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
@@ -2,8 +2,14 @@ children:
 - children:
   - children:
     - content: some content
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
@@ -3,6 +3,9 @@ children:
   - content: '{name}`some econtent`
 
       '
+    range:
+    - 0
+    - 1
     type: RawText
   language: ''
   range:

--- a/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
@@ -1,11 +1,20 @@
 children:
 - children:
   - content: 'a '
+    range:
+    - 1
+    - 1
     type: RawText
   - children:
     - content: some content
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
@@ -2,8 +2,14 @@ children:
 - children:
   - children:
     - content: '``some content``'
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
@@ -2,8 +2,14 @@ children:
 - children:
   - children:
     - content: '*content*'
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
@@ -2,8 +2,14 @@ children:
 - children:
   - children:
     - content: some $content$
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
@@ -2,15 +2,30 @@ children:
 - children:
   - children:
     - content: some content
+      range:
+      - 1
+      - 1
       type: RawText
     name: name
+    range:
+    - 1
+    - 1
     type: Role
   - content: '  '
+    range:
+    - 1
+    - 1
     type: RawText
   - children:
     - content: other
+      range:
+      - 1
+      - 1
       type: RawText
     name: name2
+    range:
+    - 1
+    - 1
     type: Role
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_table.yml
+++ b/tests/test_syntax/test_ast/test_table.yml
@@ -1,0 +1,81 @@
+children:
+- children:
+  - children:
+    - align: null
+      children:
+      - content: hjk
+        type: RawText
+      range:
+      - 3
+      - 3
+      type: TableCell
+    - align: null
+      children:
+      - children:
+        - content: y
+          type: RawText
+        type: Emphasis
+      range:
+      - 3
+      - 3
+      type: TableCell
+    - align: 0
+      children:
+      - content: z
+        type: RawText
+      range:
+      - 3
+      - 3
+      type: TableCell
+    range:
+    - 3
+    - 3
+    row_align:
+    - null
+    - null
+    - 0
+    type: TableRow
+  column_align:
+  - null
+  - null
+  - 0
+  header:
+    children:
+    - align: null
+      children:
+      - content: abc
+        type: RawText
+      range:
+      - 1
+      - 1
+      type: TableCell
+    - align: null
+      children:
+      - content: d
+        type: RawText
+      range:
+      - 1
+      - 1
+      type: TableCell
+    - align: 0
+      children:
+      - content: e
+        type: RawText
+      range:
+      - 1
+      - 1
+      type: TableCell
+    range:
+    - 1
+    - 1
+    row_align:
+    - null
+    - null
+    - 0
+    type: TableRow
+  range:
+  - 1
+  - 3
+  type: Table
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_table.yml
+++ b/tests/test_syntax/test_ast/test_table.yml
@@ -4,6 +4,9 @@ children:
     - align: null
       children:
       - content: hjk
+        range:
+        - 3
+        - 3
         type: RawText
       range:
       - 3
@@ -13,7 +16,13 @@ children:
       children:
       - children:
         - content: y
+          range:
+          - 3
+          - 3
           type: RawText
+        range:
+        - 3
+        - 3
         type: Emphasis
       range:
       - 3
@@ -22,6 +31,9 @@ children:
     - align: 0
       children:
       - content: z
+        range:
+        - 3
+        - 3
         type: RawText
       range:
       - 3

--- a/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: target
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: target
     type: Target
   range:

--- a/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
@@ -2,9 +2,18 @@ children:
 - children:
   - children:
     - content: (
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     type: EscapeSequence
   - content: target)=
+    range:
+    - 1
+    - 1
     type: RawText
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
@@ -3,9 +3,18 @@ children:
   - children:
     - children:
       - content: target
+        range:
+        - 1
+        - 1
         type: RawText
+      range:
+      - 1
+      - 1
       target: target
       type: Target
+    range:
+    - 1
+    - 1
     type: Emphasis
   range:
   - 1

--- a/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: target
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: target
     type: Target
   range:

--- a/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
@@ -3,6 +3,9 @@ children:
   - content: '(target)=
 
       '
+    range:
+    - 0
+    - 1
     type: RawText
   language: ''
   range:

--- a/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
@@ -1,10 +1,19 @@
 children:
 - children:
   - content: 'a '
+    range:
+    - 1
+    - 1
     type: RawText
   - children:
     - content: target
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: target
     type: Target
   range:

--- a/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
@@ -2,7 +2,13 @@ children:
 - children:
   - children:
     - content: '*target*'
+      range:
+      - 1
+      - 1
       type: RawText
+    range:
+    - 1
+    - 1
     target: '*target*'
     type: Target
   range:


### PR DESCRIPTION
This PR introduces introduce a `traverse` method for recursively walking through the Markdown syntax tree (see https://232-240151150-gh.circle-artifacts.com/0/html/using/use_api.html#convert-text-to-tokens). This function is then used to walk through the final syntax tree and add line numbers to span items. This allows the line numbers to be reported by docutils/sphinx in warnings/errors (e.g. if a `ref` role references an unknown name).

Note, this is a placeholder for implementing proper span level range determination (including start/end character attributes), as currently the line will refer to e.g. the first line of the paragraph that the `ref` is in rather than necessarily the actual line it is on.