### PR TITLE
Update to `mistletoe-ebp==0.9.4a2` dependency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "autoDocstring.customTemplatePath": "docstring.fmt.mustache"
+    "autoDocstring.customTemplatePath": "docstring.fmt.mustache",
+    "python.pythonPath": "/anaconda/envs/ebp/bin/python"
 }

--- a/docs/api/tokens.rst
+++ b/docs/api/tokens.rst
@@ -43,16 +43,6 @@ Role
     :exclude-members: __init__
 
 
-Math
-....
-
-.. autoclass:: myst_parser.span_tokens.Math
-    :members:
-    :no-undoc-members:
-    :show-inheritance:
-    :exclude-members: __init__
-
-
 Target
 ......
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,7 @@ autodoc_default_options = {
 autodoc_member_order = "bysource"
 
 nitpick_ignore = [
+    ("py:class", "Any"),
     ("py:class", "Tuple"),
     ("py:class", "ForwardRef"),
     ("py:class", "NoneType"),

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.5.0a1"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/block_tokens.py
+++ b/myst_parser/block_tokens.py
@@ -4,37 +4,8 @@ from typing import Tuple
 import attr
 
 from mistletoe import block_tokens
-from mistletoe.block_tokens import (  # noqa: F401
-    FrontMatter,
-    HTMLBlock,
-    Heading,
-    LinkDefinition,
-    ThematicBreak,
-    Table,
-    TableRow,
-    BlockCode,
-    CodeFence,
-)
+from mistletoe.block_tokens import Heading, ThematicBreak, CodeFence
 from mistletoe.attr_doc import autodoc
-
-"""
-Tokens to be included in the parsing process, in the order specified.
-"""
-__all__ = [
-    "HTMLBlock",
-    "LineComment",
-    "BlockCode",
-    "Heading",
-    "Quote",
-    "CodeFence",
-    "ThematicBreak",
-    "BlockBreak",
-    "List",
-    "Table",
-    "LinkDefinition",
-    "Paragraph",
-    "FrontMatter",
-]
 
 
 @autodoc
@@ -69,10 +40,10 @@ class Document(block_tokens.Document):
             # TODO this is a placeholder for implementing span level range storage
             # (with start/end character attributes)
             for result in doc.walk():
-                if not hasattr(result.node, "position"):
+                if getattr(result.node, "position", None) is None:
                     try:
                         result.node.position = result.parent.position
-                    except AttributeError:
+                    except (AttributeError, TypeError):
                         raise
         return doc
 
@@ -157,7 +128,10 @@ class BlockBreak(block_tokens.BlockToken):
 @autodoc
 @attr.s(slots=True, kw_only=True)
 class Quote(block_tokens.Quote):
-    """Quote token. (`["> # heading\\n", "> paragraph\\n"]`)."""
+    """Quote token. (`["> # heading\\n", "> paragraph\\n"]`).
+
+    MyST variant, that includes transitions to `LineComment` and `BlockBreak`.
+    """
 
     @classmethod
     def transition(cls, next_line):
@@ -179,6 +153,8 @@ class Paragraph(block_tokens.Paragraph):
     """Paragraph token. (`["some\\n", "continuous\\n", "lines\\n"]`)
 
     Boundary between span-level and block-level tokens.
+
+    MyST variant, that includes transitions to `LineComment` and `BlockBreak`.
     """
 
     @classmethod
@@ -197,7 +173,10 @@ class Paragraph(block_tokens.Paragraph):
 @autodoc
 @attr.s(slots=True, kw_only=True)
 class List(block_tokens.List):
-    """List token (unordered or ordered)"""
+    """List token (unordered or ordered)
+
+    MyST variant, that includes transitions to `LineComment` and `BlockBreak`.
+    """
 
     @classmethod
     def read(cls, lines):
@@ -244,6 +223,8 @@ class ListItem(block_tokens.ListItem):
     """List items.
 
     Not included in the parsing process, but called by List.
+
+    MyST variant, that includes transitions to `LineComment` and `BlockBreak`.
     """
 
     @staticmethod

--- a/myst_parser/json_renderer.py
+++ b/myst_parser/json_renderer.py
@@ -1,24 +1,41 @@
 """JSON renderer for myst."""
-from itertools import chain
-
-from mistletoe.parse_context import ParseContext, set_parse_context, tokens_from_module
+from mistletoe import block_tokens, block_tokens_ext, span_tokens, span_tokens_ext
 from mistletoe.renderers import json
 
-from myst_parser import span_tokens
-from myst_parser import block_tokens
+from myst_parser.block_tokens import LineComment, BlockBreak, Quote, Paragraph, List
+from myst_parser.span_tokens import Role, Target
 
 
 class JsonRenderer(json.JsonRenderer):
-    def __init__(self):
-        """This AST render uses the same block/span tokens as the docutils renderer."""
-        super().__init__()
-        myst_span_tokens = tokens_from_module(span_tokens)
-        myst_block_tokens = tokens_from_module(block_tokens)
+    """This JSON render uses the MyST spec block and span tokens.
+    """
 
-        for token in chain(myst_span_tokens, myst_block_tokens):
-            render_func = getattr(self, self._cls_to_func(token.__name__))
-            self.render_map[token.__name__] = render_func
+    default_block_tokens = (
+        block_tokens.HTMLBlock,
+        LineComment,
+        block_tokens.BlockCode,
+        block_tokens.Heading,
+        Quote,
+        block_tokens.CodeFence,
+        block_tokens.ThematicBreak,
+        BlockBreak,
+        List,
+        block_tokens_ext.Table,
+        block_tokens.LinkDefinition,
+        Paragraph,
+    )
 
-        parse_context = ParseContext(myst_block_tokens, myst_span_tokens)
-        set_parse_context(parse_context)
-        self.parse_context = parse_context.copy()
+    default_span_tokens = (
+        span_tokens.EscapeSequence,
+        Role,
+        span_tokens.HTMLSpan,
+        span_tokens.AutoLink,
+        Target,
+        span_tokens.CoreTokens,
+        span_tokens_ext.Math,
+        # TODO there is no matching core element in docutils for strikethrough
+        # span_tokens_ext.Strikethrough,
+        span_tokens.InlineCode,
+        span_tokens.LineBreak,
+        span_tokens.RawText,
+    )

--- a/myst_parser/span_tokens.py
+++ b/myst_parser/span_tokens.py
@@ -1,60 +1,16 @@
 import re
-from threading import local
+from typing import Pattern, Tuple
 
-from mistletoe import span_tokens, nested_tokenizer
-from mistletoe.span_tokens import (  # noqa F401
-    HTMLSpan,
-    Emphasis,
-    EscapeSequence,
-    AutoLink,
-    Image,
-    LineBreak,
-    Link,
-    RawText,
-    Strong,
-)
+import attr
 
-"""
-Tokens to be included in the parsing process, in the order specified.
-RawText is last as a 'fallback' token
-"""
-__all__ = (
-    "Role",
-    "HTMLSpan",
-    "EscapeSequence",
-    "AutoLink",
-    "Target",
-    "CoreTokens",
-    "Math",
-    "InlineCode",
-    "LineBreak",
-    "RawText",
-)
-# Note Strikethrough is left out from the core mistletoe tokens,
-# since there is no matching element in docutils
+from mistletoe import span_tokens
+from mistletoe.attr_doc import autodoc
+
+__all__ = ("Role", "Target")
 
 
-_core_matches = local()
-_core_matches.value = {}
-
-
-class CoreTokens(span_tokens.SpanToken):
-    precedence = 3
-
-    def __new__(self, match):
-        return globals()[match.type](match)
-
-    @classmethod
-    def find(cls, string):
-        return find_core_tokens(string)
-
-
-class InlineCode(span_tokens.InlineCode):
-    @classmethod
-    def find(cls, string):
-        return _core_matches.value.pop("InlineCode", [])
-
-
+@autodoc
+@attr.s(kw_only=True, slots=True)
 class Role(span_tokens.SpanToken):
     """
     Inline role tokens. ("{name}`some code`")
@@ -66,115 +22,44 @@ class Role(span_tokens.SpanToken):
     )
     parse_inner = False
 
-    def __init__(self, match):
-        self.role_name = match.group(1)
+    role_name: str = attr.ib(metadata={"doc": "The name of the extension point"})
+    children = attr.ib(metadata={"doc": "a single RawText node for alternative text."})
+    position: Tuple[int, int] = attr.ib(
+        default=None,
+        repr=False,
+        metadata={"doc": "Line position in source text (start, end)"},
+    )
+
+    @classmethod
+    def read(cls, match: Pattern):
         content = match.group(3)
-        self.children = (
-            span_tokens.RawText(" ".join(re.split("[ \n]+", content.strip()))),
+        return cls(
+            role_name=match.group(1),
+            children=[
+                span_tokens.RawText(" ".join(re.split("[ \n]+", content.strip())))
+            ],
         )
 
 
-class Math(span_tokens.SpanToken):
-
-    pattern = re.compile(r"(?<!\\)(?:\\\\)*(\${1,2})([^\$]+?)\1")
-
-    parse_inner = False
-    parse_group = 0
-    precedence = 2
-
-    @classmethod
-    def find(cls, string):
-        return _core_matches.value.pop("Math", [])
-
-
+@autodoc
+@attr.s(kw_only=True, slots=True)
 class Target(span_tokens.SpanToken):
-    """Target tokens. ("(target name)")"""
+    """Target tokens. ("(target name)=")"""
 
     pattern = re.compile(r"(?<!\\)(?:\\\\)*\((.+?)\)\=", re.DOTALL)
     parse_inner = False
 
-    def __init__(self, match):
-        content = match.group(self.parse_group)
-        self.children = (RawText(content),)
-        self.target = content
+    target: str = attr.ib(metadata={"doc": "link target"})
+    children = attr.ib(
+        factory=list, metadata={"doc": "a single RawText node for alternative text."}
+    )
+    position: Tuple[int, int] = attr.ib(
+        default=None,
+        repr=False,
+        metadata={"doc": "Line position in source text (start, end)"},
+    )
 
-
-def find_core_tokens(string):
-    # TODO add speed comparison to original mistletoe implementation
-    matches = []
-    # escaped denotes that the last cursor position had `\`
-    escaped = False
-    # delimiter runs are sequences of `*` or `_`
-    in_delimiter_run = None
-    delimiters = []
-    in_image = False
-    start = 0
-    i = 0
-
-    def _advance_block_regexes(_cursor):
-        # TODO Role, etc should probably be added here as well, but add more tests
-        # to test_ast first (particularly with mixed span blocks / *'s)
-        # TODO lazy pattern search?
-        return [
-            ("InlineCode", InlineCode.pattern.search(string, _cursor)),
-            ("Math", Math.pattern.search(string, _cursor)),
-        ]
-
-    next_span_blocks = _advance_block_regexes(i)
-    while i < len(string):
-
-        # look for there span block (that does not nest any other spans)
-        span_block_found = False
-        for span_name, span_match in next_span_blocks:
-            if span_match is not None and i == span_match.start():
-                # restart delimiter runs:
-                if in_delimiter_run:
-                    delimiters.append(nested_tokenizer.Delimiter(start, i, string))
-                in_delimiter_run = None
-
-                _core_matches.value.setdefault(span_name, []).append(span_match)
-                i = span_match.end()
-                next_span_blocks = _advance_block_regexes(i)
-                span_block_found = True
-                break
-        if span_block_found:
-            continue
-
-        c = string[i]
-        # if the cursor position is escaped, record and advance
-        if c == "\\" and not escaped:
-            escaped = True
-            i += 1
-            continue
-        # if the cursor reaches the end of a delimiter run,
-        # record the delimiter and reset
-        if in_delimiter_run is not None and (c != in_delimiter_run or escaped):
-            delimiters.append(
-                nested_tokenizer.Delimiter(start, i if not escaped else i - 1, string)
-            )
-            in_delimiter_run = None
-        # if the cursor reaches a new delimiter, start a delimiter run
-        if in_delimiter_run is None and (c in {"*", "_"}) and not escaped:
-            in_delimiter_run = c
-            start = i
-        if not escaped:
-            if c == "[":
-                if not in_image:
-                    delimiters.append(nested_tokenizer.Delimiter(i, i + 1, string))
-                else:
-                    delimiters.append(nested_tokenizer.Delimiter(i - 1, i + 1, string))
-                    in_image = False
-            elif c == "!":
-                in_image = True
-            elif c == "]":
-                i = nested_tokenizer.find_link_image(string, i, delimiters, matches)
-                next_span_blocks = _advance_block_regexes(i)
-            elif in_image:
-                in_image = False
-        else:
-            escaped = False
-        i += 1
-    if in_delimiter_run:
-        delimiters.append(nested_tokenizer.Delimiter(start, i, string))
-    nested_tokenizer.process_emphasis(string, None, delimiters, matches)
-    return matches
+    @classmethod
+    def read(cls, match: Pattern):
+        content = match.group(cls.parse_group)
+        return cls(target=content, children=[span_tokens.RawText.read(content)])

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.9.3"],
+    install_requires=["mistletoe-ebp==0.9.4a2"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -45,9 +45,9 @@ def test_walk(json_renderer):
         ("RawText()", "Paragraph(children=2, position=(1, 1))", 2),
         ("Strong(children=1)", "Paragraph(children=2, position=(1, 1))", 2),
         ("RawText()", "Paragraph(children=2, position=(3, 3))", 2),
-        ("Link(children=1)", "Paragraph(children=2, position=(3, 3))", 2),
+        ("Link(target='link', title='')", "Paragraph(children=2, position=(3, 3))", 2),
         ("RawText()", "Strong(children=1)", 3),
-        ("Emphasis(children=1)", "Link(children=1)", 3),
+        ("Emphasis(children=1)", "Link(target='link', title='')", 3),
         ("RawText()", "Emphasis(children=1)", 4),
     ]
 

--- a/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
@@ -6,5 +6,6 @@ front_matter:
   position:
   - 0
   - 3
+  type: FrontMatter
 link_definitions: {}
 type: Document


### PR DESCRIPTION
This update allows us to drop most of the span token patching code, and we now use the `Math` token directly from mistletoe.

It also improves how token sets are instantiated within the renderers, making it a lot easier to swap in/out tokens to be included in the parse.