### PR TITLE
Add Footnote Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@
 [![Documentation Status][rtd-badge]][rtd-link]
 [![Code style: black][black-badge]][black-link]
 [![PyPI][pypi-badge]][pypi-link]
-<!-- [![Conda][conda-badge]][conda-link] -->
+[![Conda][conda-badge]][conda-link]
 
 An extended commonmark compliant parser, with bridges to docutils & sphinx.
 
 ## Usage
+
+To install the MyST parser, run the following in a
+[Conda environment](https://docs.conda.io) (recommended):
+
+```bash
+conda install -c conda-forge myst-parser
+```
+
+or
 
 ```bash
 pip install myst-parser[sphinx]
@@ -25,86 +34,6 @@ pip install -e .[sphinx,code_style,testing,rtd]
 ```
 
 To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to your `conf.py`.
-
-## Parsed Token Classes
-
-For more information, also see the [CommonMark Spec](https://spec.commonmark.org/0.28/).
-
-### Block Tokens
-
-- **FrontMatter**: A YAML block at the start of the document enclosed by `---`
-- **HTMLBlock**: Any valid HTML (rendered in HTML output only)
-- **LineComment**: `% this is a comment`
-- **BlockCode**: indented text (4 spaces)
-- **Heading**: `# Heading` (levels 1-6)
-- **SetextHeading**: underlined header
-- **Quote**: `> this is a quote`
-- **CodeFence**: enclosed in 3 or more backticks.
-  If it starts with a `{name}`, then treated as directive.
-- **ThematicBreak**: `---`
-- **List**: bullet points or enumerated.
-- **Table**: Standard markdown table styles.
-- **Footnote**: A substitution for an inline link (e.g. `[key][name]`), which can have a reference target (no spaces), and an optional title (in `"`), e.g. `[key]: https://www.google.com "a title"`
-- **Paragraph**: General inline text
-
-### Span (Inline) Tokens
-
-- **Role**: `` `{name}`interpreted text` ``
-- **Math**: `$a=1$` or `$$a=1$$`
-- **HTMLSpan**: any valid HTML (rendered in HTML output only)
-- **EscapeSequence**: `\*`
-- **AutoLink**: `<http://www.google.com>`
-- **Target**: `(target)=` (precedes element to target, e.g. header)
-- **InlineCode**: `` `a=1` ``
-- **LineBreak**: Soft or hard (ends with spaces or `\`)
-- **Image**: `![alt](src "title")`
-- **Link**: `[text](target "title")` or `[text][key]` (key from `Footnote`)
-- **Strong**: `**strong**`
-- **Emphasis**: `*emphasis*`
-- **RawText**
-
-## Contributing
-
-### Code Style
-
-Code style is tested using [flake8](http://flake8.pycqa.org),
-with the configuration set in `.flake8`,
-and code formatted with [black](https://github.com/ambv/black).
-
-Installing with `myst-parser[code_style]` makes the [pre-commit](https://pre-commit.com/)
-package available, which will ensure this style is met before commits are submitted, by reformatting the code
-and testing for lint errors.
-It can be setup by:
-
-```shell
->> cd MyST-Parser
->> pre-commit install
-```
-
-Optionally you can run `black` and `flake8` separately:
-
-```shell
->> black .
->> flake8 .
-```
-
-Editors like VS Code also have automatic code reformat utilities, which can adhere to this standard.
-
-### Pull Requests
-
-To contribute, make Pull Requests to the `master` branch (this is the default branch). A PR can consist of one or multiple commits. Before you open a PR, make sure to clean up your commit history and create the commits that you think best divide up the total work as outlined above (use `git rebase` and `git commit --amend`). Ensure all commit messages clearly summarise the changes in the header and the problem that this commit is solving in the body.
-
-Merging pull requests: There are three ways of 'merging' pull requests on GitHub:
-
-- Squash and merge: take all commits, squash them into a single one and put it on top of the base branch.
-    Choose this for pull requests that address a single issue and are well represented by a single commit.
-    Make sure to clean the commit message (title & body)
-- Rebase and merge: take all commits and 'recreate' them on top of the base branch. All commits will be recreated with new hashes.
-    Choose this for pull requests that require more than a single commit.
-    Examples: PRs that contain multiple commits with individually significant changes; PRs that have commits from different authors (squashing commits would remove attribution)
-- Merge with merge commit: put all commits as they are on the base branch, with a merge commit on top
-    Choose for collaborative PRs with many commits. Here, the merge commit provides actual benefits.
-
 
 [travis-badge]: https://travis-ci.org/ExecutableBookProject/MyST-Parser.svg?branch=master
 [travis-link]: https://travis-ci.org/ExecutableBookProject/MyST-Parser

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -1,5 +1,11 @@
 # Contributing
 
+[![CI Status][travis-badge]][travis-link]
+[![Coverage][coveralls-badge]][coveralls-link]
+[![CircleCI][circleci-badge]][circleci-link]
+[![Documentation Status][rtd-badge]][rtd-link]
+[![Code style: black][black-badge]][black-link]
+
 ## Code Style
 
 Code style is tested using [flake8](http://flake8.pycqa.org),
@@ -63,3 +69,14 @@ Merging pull requests: There are three ways of 'merging' pull requests on GitHub
     Examples: PRs that contain multiple commits with individually significant changes; PRs that have commits from different authors (squashing commits would remove attribution)
 - Merge with merge commit: put all commits as they are on the base branch, with a merge commit on top
     Choose for collaborative PRs with many commits. Here, the merge commit provides actual benefits.
+
+[travis-badge]: https://travis-ci.org/ExecutableBookProject/MyST-Parser.svg?branch=master
+[travis-link]: https://travis-ci.org/ExecutableBookProject/MyST-Parser
+[coveralls-badge]: https://coveralls.io/repos/github/ExecutableBookProject/MyST-Parser/badge.svg?branch=master
+[coveralls-link]: https://coveralls.io/github/ExecutableBookProject/MyST-Parser?branch=master
+[circleci-badge]: https://circleci.com/gh/ExecutableBookProject/MyST-Parser.svg?style=shield
+[circleci-link]: https://circleci.com/gh/ExecutableBookProject/MyST-Parser
+[rtd-badge]: https://readthedocs.org/projects/myst-parser/badge/?version=latest
+[rtd-link]: https://myst-parser.readthedocs.io/en/latest/?badge=latest
+[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
+[black-link]: https://github.com/ambv/black

--- a/docs/using/index.md
+++ b/docs/using/index.md
@@ -5,8 +5,8 @@ MyST documents.
 
 ```{toctree}
 install.md
-sphinx.md
 syntax.md
+sphinx.md
 benchmark.md
 use_api.md
 ```

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -5,7 +5,14 @@ Installing the MyST parser provides access to two tools:
 * A MyST-to-docutils parser and renderer.
 * A Sphinx parser that utilizes the above tool in building your documenation.
 
-To install the MyST parser, run the following:
+To install the MyST parser, run the following in a
+[Conda environment](https://docs.conda.io) (recommended):
+
+```bash
+conda install -c conda-forge myst-parser
+```
+
+or
 
 ```bash
 pip install myst-parser[sphinx]

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -1,5 +1,8 @@
 # Installing the MyST Parser
 
+[![PyPI][pypi-badge]][pypi-link]
+[![Conda][conda-badge]][conda-link]
+
 Installing the MyST parser provides access to two tools:
 
 * A MyST-to-docutils parser and renderer.
@@ -26,3 +29,8 @@ cd MyST-Parser
 git checkout master
 pip install -e .[sphinx,code_style,testing,rtd]
 ```
+
+[pypi-badge]: https://img.shields.io/pypi/v/myst-parser.svg
+[pypi-link]: https://pypi.org/project/myst-parser
+[conda-badge]: https://anaconda.org/conda-forge/myst-parser/badges/version.svg
+[conda-link]: https://anaconda.org/conda-forge/myst-parser

--- a/docs/using/sphinx.md
+++ b/docs/using/sphinx.md
@@ -1,4 +1,4 @@
-# Parsing MyST with the Sphinx Document Generator
+# Parsing MyST with Sphinx
 
 Sphinx is a documentation generator for building a website or book from multiple source documents and assets. To get started with Sphinx, see their [Quickstart Guide](https://www.sphinx-doc.org/en/master/usage/quickstart.html).
 

--- a/docs/using/sphinx.md
+++ b/docs/using/sphinx.md
@@ -1,4 +1,4 @@
-# Using with the Sphinx Document Generator
+# Parsing MyST with the Sphinx Document Generator
 
 Sphinx is a documentation generator for building a website or book from multiple source documents and assets. To get started with Sphinx, see their [Quickstart Guide](https://www.sphinx-doc.org/en/master/usage/quickstart.html).
 

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -709,7 +709,8 @@ this page: [my text](example_syntax).
 
 ### Footnotes
 
-Footnote labels can be any alpha-numeric string (no spaces), and are case-insensitive.
+Footnote labels **start with `^`** and can then be any alpha-numeric string (no spaces),
+which is case-insensitive.
 The actual label is not displayed in the rendered text; instead they are numbered,
 in the order which they are referenced.
 All footnote definitions are collected, and displayed at the bottom of the page

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -709,6 +709,13 @@ this page: [my text](example_syntax).
 
 ### Footnotes
 
+Footnote labels can be any alpha-numeric string (no spaces), and are case-insensitive.
+The actual label is not displayed in the rendered text; instead they are numbered,
+in the order which they are referenced.
+All footnote definitions are collected, and displayed at the bottom of the page
+(ordered by number).
+Note that un-referenced footnote definitions will not be displayed.
+
 ```md
 This is a footnote reference.[^myref]
 
@@ -719,13 +726,24 @@ This is a footnote reference.[^myref]
 
 [^myref]: This is the footnote definition.
 
-```{important}
+````{important}
 Although footnote references can be used just fine within directives, e.g.[^myref],
-it it recommended that footnote definitions are not set here.
+it it recommended that footnote definitions are not set within directives,
+unless they will only be referenced within that same directive:
+
+```md
+[^other]
+
+[^other]: A definition within a directive
+```
+
+[^other]
+
+[^other]: A definition within a directive
 
 This is because, in the current implementation, they may not be available to
 reference in text above that particular directive.
-```
+````
 
 ````{note}
 Currently, footnote definitions may only be on a single line.

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -229,7 +229,7 @@ For more information, also see the [CommonMark Spec](https://spec.commonmark.org
     `a=1`
     ```
 * - LineBreak
-  - Soft or hard (ends with spaces or \)
+  - Soft or hard (ends with spaces or backslash)
   - ```md
     A hard break\
     ```

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -1,6 +1,6 @@
 (example_syntax)=
 
-# Example syntax for MyST
+# The MyST Syntax Guide
 
 As a base, MyST adheres to the [CommonMark specification](https://spec.commonmark.org/).
 For this, it uses the {ref}`mistletoe:intro/top-level` parser,
@@ -24,72 +24,241 @@ and further details of a few major extensions from the CommonMark flavor of mark
 
 ## Parsed Token Classes
 
+MyST builds on the tokens defined by mistletoe, to extend the syntax:
+
+- {ref}`Core block tokens <mistletoe:tokens/block>`
+- {ref}`Core span tokens <mistletoe:tokens/span>`
+- {ref}`Extension tokens <mistletoe:tokens/extension>`
+
 Tokens are listed in their order of precedence.
 For more information, also see the [CommonMark Spec](https://spec.commonmark.org/0.28/), which the parser is tested against.
+
+```{seealso}
+{ref}`Token API <api/tokens>`
+```
 
 ### Block Tokens
 
 #### Extended block tokens
 
-- **FrontMatter**: A YAML block at the start of the document enclosed by `---`. See
-  {ref}`syntax/frontmatter` for more information.
-- **Directives**: enclosed in 3 or more backticks followed by the directive name wrapped
+`````{list-table}
+:header-rows: 1
+:widths: 10 20 20
+
+* - Token
+  - Description
+  - Example
+* - FrontMatter
+  - A YAML block at the start of the document enclosed by `---`
+  - ```yaml
+    ---
+    key: value
+    ---
+    ```
+* - Directives
+  - enclosed in 3 or more backticks followed by the directive name wrapped
   in curly brackets `{}`. See {ref}`syntax/directives` for more details.
-- **Math**: Two `$` characters wrapping multi-line math, e.g.
+  - ````md
+    ```{directive}
+    :option: value
 
-  ```latex
-  $$
-  a=1
-  $$
-  ```
-
-- **LineComment**: `% this is a comment`. See {ref}`syntax/comments` for more
-  information.
-- **BlockBreak**: `+++`. See {ref}`syntax/blockbreaks` for more information.
+    content
+    ```
+    ````
+* - Math
+  - Two `$` characters wrapping multi-line math
+  - ```latex
+    $$
+    a=1
+    $$
+    ```
+* - Table
+  - Standard markdown table style, with pipe separation.
+  - ```md
+    | a    | b    |
+    | :--- | ---: |
+    | c    | d    |
+    ```
+* - LineComment
+  - A commented line. See {ref}`syntax/comments` for more information.
+  - ```latex
+    % this is a comment
+    ```
+* - BlockBreak
+  - Define blocks of text. See {ref}`syntax/blockbreaks` for more information.
+  - ```md
+    +++ {"meta": "data"}
+    ```
+* - Footnote
+  - A definition for a referencing footnote, that is placed at the bottom of the document.
+   See {ref}`syntax/footnotes` for more details.
+  - ```md
+    [^ref]: Some footnote text
+    ```
+`````
 
 #### CommonMark tokens
 
-- **HTMLBlock**: Any valid HTML (rendered in HTML output only)
-- **BlockCode**: indented text (4 spaces)
-- **Heading**: `# Heading` (levels 1-6)
-- **SetextHeading**: underlined header (using multiple `=` or `-`)
-- **Quote**: `> this is a quote`
-- **CodeFence**: enclosed in 3 or more backticks with an optional language name. E.g.:
+`````{list-table}
+:header-rows: 1
+:widths: 10 20 20
 
-  ````md
-  ```python
-  print('this is python')
-  ```
-  ````
+* - Token
+  - Description
+  - Example
+* - HTMLBlock
+  - Any valid HTML (rendered in HTML output only)
+  - ```html
+    <p>some text</p>
+    ```
+* - BlockCode
+  - indented text (4 spaces or a tab)
+  - ```md
+        included as literal *text*
+    ```
+* - Heading
+  - Level 1-6 headings, denoted by number of `#`
+  - ```md
+    ### Heading level 3
+    ```
+* - SetextHeading
+  - Underlined header (using multiple `=` or `-`)
+  - ```md
+    Header
+    ======
+    ```
+* - Quote
+  - quoted text
+  - ```md
+    > this is a quote
+    ```
+* - CodeFence
+  - enclosed in 3 or more backticks with an optional language name
+  - ````md
+    ```python
+    print('this is python')
+    ```
+    ````
+* - ThematicBreak
+  - Creates a horizontal line in the output
+  - ```md
+    ---
+    ```
+* - List
+  - bullet points or enumerated.
+  - ```md
+    - item
+      - nested item
+    1. numbered item
+    ```
+* - LinkDefinition
+  -  A substitution for an inline link, which can have a reference target (no spaces), and an optional title (in `"`)
+  - ```md
+    [key]: https://www.google.com "a title"
+    ```
+* - Paragraph
+  - General inline text
+  - ```md
+    any *text*
+    ```
 
-- **ThematicBreak**: `---`
-- **List**: bullet points or enumerated.
-- **Table**: Standard markdown table styles.
-- **LinkDefinition**: A substitution for an inline link (e.g. `[key][name]`), which can have a reference target (no spaces), and an optional title (in `"`), e.g. `[key]: https://www.google.com "a title"`
-- **Paragraph**: General inline text
+`````
 
 ### Span (Inline) Tokens
 
 #### Extended inline tokens
 
-- **Role**: `` `{rolename}`interpreted text` ``. See {ref}`syntax/roles` for more
+`````{list-table}
+:header-rows: 1
+:widths: 10 20 20
+
+* - Token
+  - Description
+  - Example
+* - Role
+  - See {ref}`syntax/roles` for more
   information.
-- **Target**: `(target)=` (precedes element to target, e.g. header). See
+  - ```md
+    `{rolename}`interpreted text`
+    ```
+* - Target
+  - Precedes element to target, e.g. header. See
   {ref}`syntax/targets` for more information.
-- **Math**: `$a=1$` or `$$a=1$$`
+  - ```md
+    (target)=
+    ```
+* - Math
+  - dollar enclosed math
+  - ```latex
+    $a=1$ or $$a=1$$
+    ```
+* - FootReference
+  - Reference a footnote. See {ref}`syntax/footnotes` for more details.
+  - ```md
+    [^abc]
+    ```
+`````
 
 #### CommonMark inline tokens
 
-- **HTMLSpan**: any valid HTML (rendered in HTML output only)
-- **EscapeSequence**: `\*`
-- **AutoLink**: `<http://www.google.com>`
-- **InlineCode**: `` `a=1` ``
-- **LineBreak**: Soft or hard (ends with spaces or `\`)
-- **Image**: `![alt](src "title")`
-- **Link**: `[text](target "title")` or `[text][key]` (key from `Footnote`)
-- **Strong**: `**strong**`
-- **Emphasis**: `*emphasis*`
-- **RawText**
+`````{list-table}
+:header-rows: 1
+:widths: 10 20 20
+
+* - Token
+  - Description
+  - Example
+* - HTMLSpan
+  - any valid HTML (rendered in HTML output only)
+  - ```html
+    <p>some text</p>
+    ```
+* - EscapeSequence
+  - escaped symbols (to avoid them being interpreted as other syntax elements)
+  - ```md
+    \*
+    ```
+* - AutoLink
+  - link that is shown in final output
+  - ```md
+    <http://www.google.com>
+    ```
+* - InlineCode
+  - literal text
+  - ```md
+    `a=1`
+    ```
+* - LineBreak
+  - Soft or hard (ends with spaces or \)
+  - ```md
+    A hard break\
+    ```
+* - Image
+  - link to an image
+  - ```md
+    ![alt](src "title")
+    ```
+* - Link
+  - Reference `LinkDefinitions`
+  - ```md
+    [text](target "title") or [text][key]
+    ```
+* - Strong
+  - bold text
+  - ```md
+    **strong**
+    ```
+* - Emphasis
+  - italic text
+  - ```md
+    *emphasis*
+    ```
+* - RawText
+  - any text
+  - ```md
+    any text
+    ```
+`````
 
 (syntax/directives)=
 
@@ -519,3 +688,17 @@ is synonymous with using the [any inline role](https://www.sphinx-doc.org/en/mas
 
 Using the same example, see this ref: [](syntax/targets), and here's a ref back to the top of
 this page: [my text](example_syntax).
+
+(syntax/footnotes)=
+
+### Footnotes
+
+```md
+This is a footnote reference.[^myref]
+
+[^myref]: This is the footnote text
+```
+
+This is a footnote reference.[^myref]
+
+[^myref]: This is the footnote text.

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -625,6 +625,22 @@ Is below, but it won't be parsed into the document.
 
 % my comment
 
+````{important}
+Since comments are a block level entity, they will terminate the previous block.
+In practical terms, this means that the following lines
+will be broken up into two paragraphs, resulting in a new line between them:
+
+```
+a line
+% a comment
+another line
+```
+
+a line
+% a comment
+another line
+````
+
 (syntax/blockbreaks)=
 
 ### Block Breaks
@@ -696,9 +712,35 @@ this page: [my text](example_syntax).
 ```md
 This is a footnote reference.[^myref]
 
-[^myref]: This is the footnote text
+[^myref]: This is the footnote definition.
 ```
 
 This is a footnote reference.[^myref]
 
-[^myref]: This is the footnote text.
+[^myref]: This is the footnote definition.
+
+```{important}
+Although footnote references can be used just fine within directives, e.g.[^myref],
+it it recommended that footnote definitions are not set here.
+
+This is because, in the current implementation, they may not be available to
+reference in text above that particular directive.
+```
+
+````{note}
+Currently, footnote definitions may only be on a single line.
+However, it is intended in an update to come, that any preceding text which is
+indented by four or more spaces, will also be included in the footnote definition, e.g.
+
+```md
+[^myref]: This is the footnote definition.
+
+    That continues for all indented lines
+
+    Plus any precding unindented lines,
+that are not separated by a blank line
+
+This is not part of the footnote.
+```
+
+````

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -720,12 +720,12 @@ Note that un-referenced footnote definitions will not be displayed.
 ```md
 This is a footnote reference.[^myref]
 
-[^myref]: This is the footnote definition.
+[^myref]: This **is** the footnote definition.
 ```
 
 This is a footnote reference.[^myref]
 
-[^myref]: This is the footnote definition.
+[^myref]: This **is** the footnote definition.
 
 ````{important}
 Although footnote references can be used just fine within directives, e.g.[^myref],

--- a/docs/using/use_api.md
+++ b/docs/using/use_api.md
@@ -5,7 +5,8 @@
 MyST-Parser may be used as an API *via* the `myst_parser` package.
 
 ```{seealso}
-- {ref}`Programmatic Use of Mistletoe <mistletoe:intro/api_use>`
+% - {ref}`Programmatic Use of Mistletoe <mistletoe:intro/api_use>`
+- {ref}`Programmatic Use of Mistletoe <mistletoe:intro/usage>`
 - {ref}`The MyST-Parser API <api/main>`
 ```
 

--- a/docs/using/use_api.md
+++ b/docs/using/use_api.md
@@ -5,8 +5,7 @@
 MyST-Parser may be used as an API *via* the `myst_parser` package.
 
 ```{seealso}
-% - {ref}`Programmatic Use of Mistletoe <mistletoe:intro/api_use>`
-- {ref}`Programmatic Use of Mistletoe <mistletoe:intro/usage>`
+- {ref}`Programmatic Use of Mistletoe <mistletoe:intro/api_use>`
 - {ref}`The MyST-Parser API <api/main>`
 ```
 

--- a/docs/using/use_api.md
+++ b/docs/using/use_api.md
@@ -2,7 +2,12 @@
 
 % TODO eventually this should be wrote as a notebook (with MyST-NB)!
 
-MyST-Parser may be used as an API *via* the `myst_parser` package, see {ref}`api/main` for full details.
+MyST-Parser may be used as an API *via* the `myst_parser` package.
+
+```{seealso}
+- {ref}`Programmatic Use of Mistletoe <mistletoe:intro/api_use>`
+- {ref}`The MyST-Parser API <api/main>`
+```
 
 The raw text is first parsed to syntax 'tokens',
 then these are converted to other formats using 'renderers'.

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0a2"
+__version__ = "0.6.0a3"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0a3"
+__version__ = "0.6.0"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0a1"
+__version__ = "0.6.0a2"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.6.0a1"
 
 
 def text_to_tokens(text: str):

--- a/myst_parser/block_tokens.py
+++ b/myst_parser/block_tokens.py
@@ -9,7 +9,7 @@ from mistletoe.attr_doc import autodoc
 
 
 @autodoc
-@attr.s(slots=True, kw_only=True)
+@attr.s(slots=False, kw_only=True)
 class Document(block_tokens.Document):
     """Document token."""
 

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -106,7 +106,7 @@ class DocutilsRenderer(BaseRenderer):
     def nested_render_text(self, text: str, lineno: int):
         """Render unparsed text."""
         token = myst_block_tokens.Document.read(
-            text, start_line=lineno, front_matter=True
+            text, start_line=lineno, front_matter=True, reset_definitions=False
         )
         # TODO think if this is the best way: here we consume front matter,
         # but then remove it. this is for example if includes have front matter
@@ -836,7 +836,10 @@ class MockState:
         )
         renderer.render(
             myst_block_tokens.Document.read(
-                text, start_line=self._lineno, front_matter=False
+                text,
+                start_line=self._lineno,
+                front_matter=False,
+                reset_definitions=False,
             )
         )
         textnodes = []

--- a/myst_parser/html_renderer.py
+++ b/myst_parser/html_renderer.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from mistletoe import block_tokens, block_tokens_ext, span_tokens, span_tokens_ext
+from mistletoe.parse_context import ParseContext
 from mistletoe.renderers import html as html_renderer
 
 from myst_parser.block_tokens import LineComment, BlockBreak, Quote, Paragraph, List
@@ -47,23 +50,25 @@ class HTMLRenderer(html_renderer.HTMLRenderer):
 
     def __init__(
         self,
-        find_blocks=None,
-        find_spans=None,
+        parse_context: Optional[ParseContext] = None,
         add_mathjax=False,
         as_standalone=False,
         add_css=None,
     ):
         """Intitalise HTML renderer
 
-        :param find_blocks: override the default block tokens (classes or class paths)
-        :param find_spans: override the default span tokens (classes or class paths)
+        :param parse_context: the parse context stores global parsing variables,
+            such as the block/span tokens to search for,
+            and link/footnote definitions that have been collected.
+            If None, a new context will be instatiated, with the default
+            block/span tokens for this renderer.
+            These will be re-instatiated on ``__enter__``.
+        :type parse_context: mistletoe.parse_context.ParseContext
         :param add_mathjax: add the mathjax CDN
         :param as_standalone: return the HTML body within a minmal HTML page
         :param add_css: if as_standalone=True, CSS to add to the header
         """
-        super().__init__(
-            find_blocks=find_blocks, find_spans=find_spans, as_standalone=False
-        )
+        super().__init__(parse_context=parse_context, as_standalone=False)
 
         self.mathjax_src = ""
         if add_mathjax:

--- a/myst_parser/json_renderer.py
+++ b/myst_parser/json_renderer.py
@@ -21,6 +21,7 @@ class JsonRenderer(json.JsonRenderer):
         BlockBreak,
         List,
         block_tokens_ext.Table,
+        block_tokens_ext.Footnote,
         block_tokens.LinkDefinition,
         Paragraph,
     )
@@ -32,6 +33,7 @@ class JsonRenderer(json.JsonRenderer):
         span_tokens.AutoLink,
         Target,
         span_tokens.CoreTokens,
+        span_tokens_ext.FootReference,
         span_tokens_ext.Math,
         # TODO there is no matching core element in docutils for strikethrough
         # span_tokens_ext.Strikethrough,

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -1,8 +1,12 @@
 from docutils import frontend, nodes
 from sphinx.parsers import Parser
+from sphinx.util import logging
 
+from mistletoe.base_elements import SourceLines
 from myst_parser.docutils_renderer import SphinxRenderer
 from myst_parser.block_tokens import Document
+
+SPHINX_LOGGER = logging.getLogger(__name__)
 
 
 class MystParser(Parser):
@@ -175,6 +179,12 @@ class MystParser(Parser):
             pass
         renderer = SphinxRenderer(document=document)
         with renderer:
-            # TODO capture parsing errors and report via docutils/sphinx
-            doc = Document.read(inputstring)
+            # Log to sphinx (e.g. to warn of duplicate link/footnote definitions)
+            renderer.parse_context.logger = SPHINX_LOGGER
+            lines = SourceLines(
+                inputstring,
+                metadata={"docname": self.env.docname},
+                standardize_ends=True,
+            )
+            doc = Document.read(lines)
             renderer.render(doc)

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -182,9 +182,7 @@ class MystParser(Parser):
             # Log to sphinx (e.g. to warn of duplicate link/footnote definitions)
             renderer.parse_context.logger = SPHINX_LOGGER
             lines = SourceLines(
-                inputstring,
-                metadata={"docname": self.env.docname},
-                standardize_ends=True,
+                inputstring, uri=document["source"], standardize_ends=True
             )
             doc = Document.read(lines)
             renderer.render(doc)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.10.0a1"],
+    install_requires=["mistletoe-ebp~=0.10.0a2"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.9.4"],
+    install_requires=["mistletoe-ebp~=0.10.0a1"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.10.0a4"],
+    install_requires=["mistletoe-ebp~=0.10"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.10.0a2"],
+    install_requires=["mistletoe-ebp~=0.10.0a3"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["mistletoe-ebp~=0.10.0a3"],
+    install_requires=["mistletoe-ebp~=0.10.0a4"],
     extras_require={
         "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -400,6 +400,34 @@ def test_link_def_in_directive_nested(renderer, file_regression):
     file_regression.check(renderer.document.pformat(), extension=".xml")
 
 
+def test_footnotes(renderer):
+    renderer.render(
+        Document.read(
+            dedent(
+                """\
+            [^a]
+
+            [^a]: footnote*text*
+            """
+            )
+        )
+    )
+    print(renderer.document.pformat())
+    assert renderer.document.pformat() == dedent(
+        """\
+    <document source="notset">
+        <paragraph>
+            <footnote_reference auto="1" ids="id1" refname="a">
+        <transition>
+        <footnote auto="1" ids="a" names="a">
+            <paragraph>
+                footnote
+                <emphasis>
+                    text
+    """
+    )
+
+
 def test_full_run(sphinx_renderer, file_regression):
     string = dedent(
         """\

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -349,6 +349,32 @@ def test_block_quotes(renderer):
     )
 
 
+def test_link_def_in_directive(renderer):
+    renderer.render(
+        Document.read(
+            dedent(
+                """\
+            ```{note}
+            [a]
+            ```
+
+            [a]: link
+            """
+            )
+        )
+    )
+    assert renderer.document.pformat() == dedent(
+        """\
+    <document source="notset">
+        <note>
+            <paragraph>
+                <pending_xref refdomain="True" refexplicit="True" reftarget="link" reftype="any" refwarn="True">
+                    <literal classes="xref any">
+                        a
+    """  # noqa: E501
+    )
+
+
 def test_full_run(sphinx_renderer, file_regression):
     string = dedent(
         """\

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -269,12 +269,16 @@ def test_cross_referencing(sphinx_renderer, file_regression):
 
 
 def test_comment(renderer_mock):
-    renderer_mock.render(tokenize_main([r"% a comment"])[0])
+    renderer_mock.render(Document.read(["line 1", r"% a comment", "line 2"]))
     assert renderer_mock.document.pformat() == dedent(
         """\
     <document source="notset">
+        <paragraph>
+            line 1
         <comment xml:space="preserve">
             a comment
+        <paragraph>
+            line 2
     """
     )
 

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -375,6 +375,31 @@ def test_link_def_in_directive(renderer):
     )
 
 
+def test_link_def_in_directive_nested(renderer, file_regression):
+    # TODO document or 'fix' the fact that [ref2] here isn't resolved
+    renderer.render(
+        Document.read(
+            dedent(
+                """\
+            ```{note}
+            [ref1]: link
+            ```
+
+            ```{note}
+            [ref1]
+            [ref2]
+            ```
+
+            ```{note}
+            [ref2]: link
+            ```
+            """
+            )
+        )
+    )
+    file_regression.check(renderer.document.pformat(), extension=".xml")
+
+
 def test_full_run(sphinx_renderer, file_regression):
     string = dedent(
         """\

--- a/tests/test_renderers/test_docutils/test_link_def_in_directive_nested.xml
+++ b/tests/test_renderers/test_docutils/test_link_def_in_directive_nested.xml
@@ -1,0 +1,10 @@
+<document source="notset">
+    <note>
+    <note>
+        <paragraph>
+            <pending_xref refdomain="True" refexplicit="True" reftarget="link" reftype="any" refwarn="True">
+                <literal classes="xref any">
+                    ref1
+            
+            [ref2]
+    <note>

--- a/tests/test_sphinx/sourcedirs/footnotes/conf.py
+++ b/tests/test_sphinx/sourcedirs/footnotes/conf.py
@@ -1,0 +1,2 @@
+extensions = ["myst_parser"]
+exclude_patterns = ["_build"]

--- a/tests/test_sphinx/sourcedirs/footnotes/footnote_md.md
+++ b/tests/test_sphinx/sourcedirs/footnotes/footnote_md.md
@@ -1,0 +1,25 @@
+# Footnotes with Markdown
+
+[^c]
+
+```{note}
+[^d]
+```
+
+[^a]
+
+[^a]: some footnote *text*
+
+[^b]: a footnote before its reference
+
+[^b]
+
+[^c]: a footnote referenced first
+
+[^d]: a footnote referenced in a directive
+
+[^123] [^123]
+
+[^123]: multiple references footnote
+
+[^x]: an unreferenced footnote

--- a/tests/test_sphinx/sourcedirs/footnotes/footnote_rst.rst
+++ b/tests/test_sphinx/sourcedirs/footnotes/footnote_rst.rst
@@ -1,0 +1,26 @@
+Footnotes with rST
+------------------
+
+[#c]_
+
+.. note::
+
+    [#d]_
+
+[#a]_
+
+.. [#a] some footnote *text*
+
+.. [#b] a footnote before its reference
+
+[#b]_
+
+.. [#c] a footnote referenced first
+
+.. [#d] a footnote referenced in a directive
+
+[#123]_ [#123]_
+
+.. [#123] multiple references footnote
+
+.. [#x] an unreferenced footnote

--- a/tests/test_sphinx/sourcedirs/footnotes/index.md
+++ b/tests/test_sphinx/sourcedirs/footnotes/index.md
@@ -1,0 +1,4 @@
+```{toctree}
+footnote_rst
+footnote_md
+```

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -44,3 +44,24 @@ def test_includes(
 
     get_sphinx_app_doctree(app, filename="index.doctree", regress=True)
     get_sphinx_app_output(app, filename="index.html", regress_html=True)
+
+
+@pytest.mark.sphinx(
+    buildername="html", srcdir=os.path.join(SOURCE_DIR, "footnotes"), freshenv=True
+)
+def test_footnotes(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    get_sphinx_app_output,
+    remove_sphinx_builds,
+):
+    """Test of include directive."""
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = warning.getvalue().strip()
+    assert warnings == ""
+    get_sphinx_app_doctree(app, filename="footnote_md.doctree", regress=True)
+    get_sphinx_app_output(app, filename="footnote_md.html", regress_html=True)

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
@@ -1,0 +1,122 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="section" id="footnotes-with-markdown">
+    <h1>
+     Footnotes with Markdown
+     <a class="headerlink" href="#footnotes-with-markdown" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <p>
+     <a class="footnote-reference brackets" href="#c" id="id1">
+      1
+     </a>
+    </p>
+    <div class="admonition note">
+     <p class="admonition-title">
+      Note
+     </p>
+     <p>
+      <a class="footnote-reference brackets" href="#d" id="id2">
+       5
+      </a>
+     </p>
+    </div>
+    <p>
+     <a class="footnote-reference brackets" href="#a" id="id3">
+      2
+     </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#b" id="id4">
+      3
+     </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#id7" id="id5">
+      4
+     </a>
+     <a class="footnote-reference brackets" href="#id7" id="id6">
+      4
+     </a>
+    </p>
+    <hr class="docutils"/>
+    <dl class="footnote brackets">
+     <dt class="label" id="c">
+      <span class="brackets">
+       <a class="fn-backref" href="#id1">
+        1
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote referenced first
+      </p>
+     </dd>
+     <dt class="label" id="a">
+      <span class="brackets">
+       <a class="fn-backref" href="#id3">
+        2
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       some footnote
+       <em>
+        text
+       </em>
+      </p>
+     </dd>
+     <dt class="label" id="b">
+      <span class="brackets">
+       <a class="fn-backref" href="#id4">
+        3
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote before its reference
+      </p>
+     </dd>
+     <dt class="label" id="id7">
+      <span class="brackets">
+       4
+      </span>
+      <span class="fn-backref">
+       (
+       <a href="#id5">
+        1
+       </a>
+       ,
+       <a href="#id6">
+        2
+       </a>
+       )
+      </span>
+     </dt>
+     <dd>
+      <p>
+       multiple references footnote
+      </p>
+     </dd>
+     <dt class="label" id="d">
+      <span class="brackets">
+       <a class="fn-backref" href="#id2">
+        5
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote referenced in a directive
+      </p>
+     </dd>
+    </dl>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
@@ -19,26 +19,26 @@
      </p>
      <p>
       <a class="footnote-reference brackets" href="#d" id="id2">
-       5
+       2
       </a>
      </p>
     </div>
     <p>
      <a class="footnote-reference brackets" href="#a" id="id3">
-      2
-     </a>
-    </p>
-    <p>
-     <a class="footnote-reference brackets" href="#b" id="id4">
       3
      </a>
     </p>
     <p>
-     <a class="footnote-reference brackets" href="#id7" id="id5">
+     <a class="footnote-reference brackets" href="#b" id="id4">
       4
      </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#id7" id="id5">
+      5
+     </a>
      <a class="footnote-reference brackets" href="#id7" id="id6">
-      4
+      5
      </a>
     </p>
     <hr class="docutils"/>
@@ -55,10 +55,22 @@
        a footnote referenced first
       </p>
      </dd>
+     <dt class="label" id="d">
+      <span class="brackets">
+       <a class="fn-backref" href="#id2">
+        2
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote referenced in a directive
+      </p>
+     </dd>
      <dt class="label" id="a">
       <span class="brackets">
        <a class="fn-backref" href="#id3">
-        2
+        3
        </a>
       </span>
      </dt>
@@ -73,7 +85,7 @@
      <dt class="label" id="b">
       <span class="brackets">
        <a class="fn-backref" href="#id4">
-        3
+        4
        </a>
       </span>
      </dt>
@@ -84,7 +96,7 @@
      </dd>
      <dt class="label" id="id7">
       <span class="brackets">
-       4
+       5
       </span>
       <span class="fn-backref">
        (
@@ -101,18 +113,6 @@
      <dd>
       <p>
        multiple references footnote
-      </p>
-     </dd>
-     <dt class="label" id="d">
-      <span class="brackets">
-       <a class="fn-backref" href="#id2">
-        5
-       </a>
-      </span>
-     </dt>
-     <dd>
-      <p>
-       a footnote referenced in a directive
       </p>
      </dd>
     </dl>

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
@@ -1,0 +1,51 @@
+<document source="footnote_md.md">
+    <section ids="footnotes-with-markdown" names="footnotes\ with\ markdown">
+        <title>
+            Footnotes with Markdown
+        <paragraph>
+            <footnote_reference auto="1" docname="footnote_md" ids="id1" refid="c">
+                1
+        <note>
+            <paragraph>
+                <footnote_reference auto="1" docname="footnote_md" ids="id2" refid="d">
+                    5
+        <paragraph>
+            <footnote_reference auto="1" docname="footnote_md" ids="id3" refid="a">
+                2
+        <paragraph>
+            <footnote_reference auto="1" docname="footnote_md" ids="id4" refid="b">
+                3
+        <paragraph>
+            <footnote_reference auto="1" docname="footnote_md" ids="id5" refid="id7">
+                4
+             
+            <footnote_reference auto="1" docname="footnote_md" ids="id6" refid="id7">
+                4
+        <transition>
+        <footnote auto="1" backrefs="id1" docname="footnote_md" ids="c" names="c">
+            <label>
+                1
+            <paragraph>
+                a footnote referenced first
+        <footnote auto="1" backrefs="id3" docname="footnote_md" ids="a" names="a">
+            <label>
+                2
+            <paragraph>
+                some footnote 
+                <emphasis>
+                    text
+        <footnote auto="1" backrefs="id4" docname="footnote_md" ids="b" names="b">
+            <label>
+                3
+            <paragraph>
+                a footnote before its reference
+        <footnote auto="1" backrefs="id5 id6" docname="footnote_md" ids="id7" names="123">
+            <label>
+                4
+            <paragraph>
+                multiple references footnote
+        <footnote auto="1" backrefs="id2" docname="footnote_md" ids="d" names="d">
+            <label>
+                5
+            <paragraph>
+                a footnote referenced in a directive

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
@@ -8,44 +8,44 @@
         <note>
             <paragraph>
                 <footnote_reference auto="1" docname="footnote_md" ids="id2" refid="d">
-                    5
+                    2
         <paragraph>
             <footnote_reference auto="1" docname="footnote_md" ids="id3" refid="a">
-                2
-        <paragraph>
-            <footnote_reference auto="1" docname="footnote_md" ids="id4" refid="b">
                 3
         <paragraph>
-            <footnote_reference auto="1" docname="footnote_md" ids="id5" refid="id7">
+            <footnote_reference auto="1" docname="footnote_md" ids="id4" refid="b">
                 4
+        <paragraph>
+            <footnote_reference auto="1" docname="footnote_md" ids="id5" refid="id7">
+                5
              
             <footnote_reference auto="1" docname="footnote_md" ids="id6" refid="id7">
-                4
+                5
         <transition>
         <footnote auto="1" backrefs="id1" docname="footnote_md" ids="c" names="c">
             <label>
                 1
             <paragraph>
                 a footnote referenced first
-        <footnote auto="1" backrefs="id3" docname="footnote_md" ids="a" names="a">
+        <footnote auto="1" backrefs="id2" docname="footnote_md" ids="d" names="d">
             <label>
                 2
+            <paragraph>
+                a footnote referenced in a directive
+        <footnote auto="1" backrefs="id3" docname="footnote_md" ids="a" names="a">
+            <label>
+                3
             <paragraph>
                 some footnote 
                 <emphasis>
                     text
         <footnote auto="1" backrefs="id4" docname="footnote_md" ids="b" names="b">
             <label>
-                3
+                4
             <paragraph>
                 a footnote before its reference
         <footnote auto="1" backrefs="id5 id6" docname="footnote_md" ids="id7" names="123">
             <label>
-                4
-            <paragraph>
-                multiple references footnote
-        <footnote auto="1" backrefs="id2" docname="footnote_md" ids="d" names="d">
-            <label>
                 5
             <paragraph>
-                a footnote referenced in a directive
+                multiple references footnote

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -34,12 +34,14 @@ def test_walk(json_renderer):
     assert tree == [
         (
             "Paragraph(children=2, position=(1, 1))",
-            "Document(children=2, link_definitions=0, front_matter=None)",
+            "Document(children=2, link_definitions=0, footnotes=0, "
+            "footref_order=0, front_matter=None)",
             1,
         ),
         (
             "Paragraph(children=2, position=(3, 3))",
-            "Document(children=2, link_definitions=0, front_matter=None)",
+            "Document(children=2, link_definitions=0, footnotes=0, "
+            "footref_order=0, front_matter=None)",
             1,
         ),
         ("RawText()", "Paragraph(children=2, position=(1, 1))", 2),

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -20,7 +20,7 @@ def test_render_tokens():
     assert root.children, root.children
 
 
-def test_walk(json_renderer):
+def test_walk(json_renderer, data_regression):
     doc = Document.read(
         dedent(
             """\
@@ -31,27 +31,7 @@ def test_walk(json_renderer):
         )
     )
     tree = [(repr(t.node), repr(t.parent), t.depth) for t in doc.walk()]
-    assert tree == [
-        (
-            "Paragraph(children=2, position=(1, 1))",
-            "Document(children=2, link_definitions=0, footnotes=0, "
-            "footref_order=0, front_matter=None)",
-            1,
-        ),
-        (
-            "Paragraph(children=2, position=(3, 3))",
-            "Document(children=2, link_definitions=0, footnotes=0, "
-            "footref_order=0, front_matter=None)",
-            1,
-        ),
-        ("RawText()", "Paragraph(children=2, position=(1, 1))", 2),
-        ("Strong(children=1)", "Paragraph(children=2, position=(1, 1))", 2),
-        ("RawText()", "Paragraph(children=2, position=(3, 3))", 2),
-        ("Link(target='link', title='')", "Paragraph(children=2, position=(3, 3))", 2),
-        ("RawText()", "Strong(children=1)", 3),
-        ("Emphasis(children=1)", "Link(target='link', title='')", 3),
-        ("RawText()", "Emphasis(children=1)", 4),
-    ]
+    data_regression.check(tree)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_syntax/test_ast/test_block_break_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_basic_strings0_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: +++
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
@@ -19,6 +19,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
@@ -3,21 +3,29 @@ children:
   - children:
     - content: +
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: EscapeSequence
   - content: ++
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_block_break_following_content_no_space_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_content_no_space_strings8_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: +++a
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_following_content_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_content_strings5_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: +++ a
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_following_space_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_space_strings6_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: '+++   '
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
@@ -31,6 +31,8 @@ children:
   - 2
   raw: +++
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
@@ -4,19 +4,25 @@ children:
     - children:
       - content: item
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: 1
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: Paragraph
     leader: '-'
     loose: false
     next_marker: null
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     prepend: 2
     type: ListItem
   loose: false

--- a/tests/test_syntax/test_ast/test_block_break_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_2_strings1_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: '  +++'
   type: BlockBreak
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
@@ -12,6 +12,8 @@ children:
   - 0
   - 1
   type: BlockCode
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
@@ -4,13 +4,17 @@ children:
 
       '
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     type: RawText
   language: ''
   position:
-  - 0
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 0
+    uri: null
   type: BlockCode
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
@@ -9,6 +9,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
@@ -2,12 +2,16 @@ children:
 - children:
   - content: a +++
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_comment_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_comment_basic_strings0_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: '% comment'
   type: LineComment
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
@@ -19,6 +19,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_comment_escaped_strings3_.yml
@@ -3,21 +3,29 @@ children:
   - children:
     - content: '%'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: EscapeSequence
   - content: ' comment'
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
@@ -31,6 +31,8 @@ children:
   - 2
   raw: '% comment'
   type: LineComment
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_comment_follows_list_strings5_.yml
@@ -4,19 +4,25 @@ children:
     - children:
       - content: item
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: 1
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: Paragraph
     leader: '-'
     loose: false
     next_marker: null
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     prepend: 2
     type: ListItem
   loose: false

--- a/tests/test_syntax/test_ast/test_comment_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_comment_indent_2_strings1_.yml
@@ -5,6 +5,8 @@ children:
   - 1
   raw: '  % comment'
   type: LineComment
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
@@ -12,6 +12,8 @@ children:
   - 0
   - 1
   type: BlockCode
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_comment_indent_4_strings2_.yml
@@ -4,13 +4,17 @@ children:
 
       '
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     type: RawText
   language: ''
   position:
-  - 0
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 0
+    uri: null
   type: BlockCode
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
@@ -2,12 +2,16 @@ children:
 - children:
   - content: a % comment
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_comment_inline_strings4_.yml
@@ -9,6 +9,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
@@ -6,8 +6,10 @@ front_matter:
 
     '
   position:
-  - 1
-  - 3
+    data: {}
+    line_end: 3
+    line_start: 1
+    uri: null
   type: FrontMatter
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
@@ -1,4 +1,6 @@
 children: []
+footnotes: {}
+footref_order: []
 front_matter:
   content: 'a: b
 

--- a/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_front_matter_basic_strings0_.yml
@@ -6,7 +6,7 @@ front_matter:
 
     '
   position:
-  - 0
+  - 1
   - 3
   type: FrontMatter
 link_definitions: {}

--- a/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
@@ -29,6 +29,8 @@ children:
   - 3
   - 3
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_escape_strings3_.yml
@@ -2,32 +2,44 @@ children:
 - children:
   - content: '[ref]'
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 - children:
   - children:
     - content: '['
       position:
-      - 3
-      - 3
+        data: {}
+        line_end: 3
+        line_start: 3
+        uri: null
       type: RawText
     position:
-    - 3
-    - 3
+      data: {}
+      line_end: 3
+      line_start: 3
+      uri: null
     type: EscapeSequence
   - content: 'ref]: https://google.com "title"'
     position:
-    - 3
-    - 3
+      data: {}
+      line_end: 3
+      line_start: 3
+      uri: null
     type: RawText
   position:
-  - 3
-  - 3
+    data: {}
+    line_end: 3
+    line_start: 3
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
@@ -3,18 +3,24 @@ children:
   - children:
     - content: ref
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: https://google.com
     title: title
     type: Link
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_first_strings0_.yml
@@ -16,6 +16,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions:
   ref:

--- a/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
@@ -16,6 +16,8 @@ children:
   - 3
   - 3
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions:
   ref:

--- a/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_last_strings1_.yml
@@ -3,18 +3,24 @@ children:
   - children:
     - content: ref
       position:
-      - 3
-      - 3
+        data: {}
+        line_end: 3
+        line_start: 3
+        uri: null
       type: RawText
     position:
-    - 3
-    - 3
+      data: {}
+      line_end: 3
+      line_start: 3
+      uri: null
     target: https://google.com
     title: title
     type: Link
   position:
-  - 3
-  - 3
+    data: {}
+    line_end: 3
+    line_start: 3
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
@@ -21,6 +21,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions:
   '*syntax*':

--- a/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_link_references_ref_syntax_strings2_.yml
@@ -4,22 +4,30 @@ children:
     - children:
       - content: syntax
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: 1
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: Emphasis
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: https://google.com
     title: title
     type: Link
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: some content
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
@@ -3,31 +3,43 @@ children:
   - children:
     - content: '{'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: EscapeSequence
   - content: name}
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   - children:
     - content: some content
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: InlineCode
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
@@ -29,6 +29,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
@@ -14,6 +14,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
@@ -3,16 +3,22 @@ children:
   - children:
     - content: '{name}`some content`'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: InlineCode
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
@@ -20,6 +20,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
@@ -4,21 +4,29 @@ children:
     - children:
       - content: content
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: 1
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       role_name: name
       type: Role
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: Emphasis
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
@@ -2,12 +2,16 @@ children:
 - children:
   - content: ${name}`some content`$
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: Math
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
@@ -9,6 +9,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: some content
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
@@ -12,6 +12,8 @@ children:
   - 0
   - 1
   type: BlockCode
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
@@ -4,13 +4,17 @@ children:
 
       '
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     type: RawText
   language: ''
   position:
-  - 0
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 0
+    uri: null
   type: BlockCode
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
@@ -20,6 +20,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
@@ -2,23 +2,31 @@ children:
 - children:
   - content: 'a '
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   - children:
     - content: some content
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: '``some content``'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: '*content*'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: some $content$
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
@@ -31,6 +31,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
@@ -3,33 +3,45 @@ children:
   - children:
     - content: some content
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name
     type: Role
   - content: '  '
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   - children:
     - content: other
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     role_name: name2
     type: Role
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_table.yml
+++ b/tests/test_syntax/test_ast/test_table.yml
@@ -98,6 +98,8 @@ children:
   - 1
   - 3
   type: Table
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_table.yml
+++ b/tests/test_syntax/test_ast/test_table.yml
@@ -5,43 +5,59 @@ children:
       children:
       - content: hjk
         position:
-        - 3
-        - 3
+          data: {}
+          line_end: null
+          line_start: 3
+          uri: null
         type: RawText
       position:
-      - 3
-      - 3
+        data: {}
+        line_end: null
+        line_start: 3
+        uri: null
       type: TableCell
     - align: null
       children:
       - children:
         - content: y
           position:
-          - 3
-          - 3
+            data: {}
+            line_end: null
+            line_start: 3
+            uri: null
           type: RawText
         position:
-        - 3
-        - 3
+          data: {}
+          line_end: null
+          line_start: 3
+          uri: null
         type: Emphasis
       position:
-      - 3
-      - 3
+        data: {}
+        line_end: null
+        line_start: 3
+        uri: null
       type: TableCell
     - align: 0
       children:
       - content: z
         position:
-        - 3
-        - 3
+          data: {}
+          line_end: null
+          line_start: 3
+          uri: null
         type: RawText
       position:
-      - 3
-      - 3
+        data: {}
+        line_end: null
+        line_start: 3
+        uri: null
       type: TableCell
     position:
-    - 3
-    - 3
+      data: {}
+      line_end: null
+      line_start: 3
+      uri: null
     row_align:
     - null
     - null
@@ -57,46 +73,62 @@ children:
       children:
       - content: abc
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: null
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: null
+        line_start: 1
+        uri: null
       type: TableCell
     - align: null
       children:
       - content: d
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: null
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: null
+        line_start: 1
+        uri: null
       type: TableCell
     - align: 0
       children:
       - content: e
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: null
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: null
+        line_start: 1
+        uri: null
       type: TableCell
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: null
+      line_start: 1
+      uri: null
     row_align:
     - null
     - null
     - 0
     type: TableRow
   position:
-  - 1
-  - 3
+    data: {}
+    line_end: 3
+    line_start: 1
+    uri: null
   type: Table
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_target_basic_strings0_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: target
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: target
     type: Target
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
@@ -19,6 +19,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_target_escaped_strings3_.yml
@@ -3,21 +3,29 @@ children:
   - children:
     - content: (
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: EscapeSequence
   - content: target)=
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
@@ -20,6 +20,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_target_external_emphasis_strings6_.yml
@@ -4,21 +4,29 @@ children:
     - children:
       - content: target
         position:
-        - 1
-        - 1
+          data: {}
+          line_end: 1
+          line_start: 1
+          uri: null
         type: RawText
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       target: target
       type: Target
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: Emphasis
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_2_strings1_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: target
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: target
     type: Target
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
@@ -12,6 +12,8 @@ children:
   - 0
   - 1
   type: BlockCode
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_target_indent_4_strings2_.yml
@@ -4,13 +4,17 @@ children:
 
       '
     position:
-    - 0
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 0
+      uri: null
     type: RawText
   language: ''
   position:
-  - 0
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 0
+    uri: null
   type: BlockCode
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
@@ -20,6 +20,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_target_inline_strings4_.yml
@@ -2,23 +2,31 @@ children:
 - children:
   - content: 'a '
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     type: RawText
   - children:
     - content: target
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: target
     type: Target
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
@@ -15,6 +15,8 @@ children:
   - 1
   - 1
   type: Paragraph
+footnotes: {}
+footref_order: []
 front_matter: null
 link_definitions: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_target_internal_emphasis_strings5_.yml
@@ -3,17 +3,23 @@ children:
   - children:
     - content: '*target*'
       position:
-      - 1
-      - 1
+        data: {}
+        line_end: 1
+        line_start: 1
+        uri: null
       type: RawText
     position:
-    - 1
-    - 1
+      data: {}
+      line_end: 1
+      line_start: 1
+      uri: null
     target: '*target*'
     type: Target
   position:
-  - 1
-  - 1
+    data: {}
+    line_end: 1
+    line_start: 1
+    uri: null
   type: Paragraph
 footnotes: {}
 footref_order: []

--- a/tests/test_syntax/test_ast/test_walk.yml
+++ b/tests/test_syntax/test_ast/test_walk.yml
@@ -1,0 +1,27 @@
+- - Paragraph(children=2, position=Position(lines=[1:1]))
+  - Document(children=2, link_definitions=0, footnotes=0, footref_order=0, front_matter=None)
+  - 1
+- - Paragraph(children=2, position=Position(lines=[3:3]))
+  - Document(children=2, link_definitions=0, footnotes=0, footref_order=0, front_matter=None)
+  - 1
+- - RawText()
+  - Paragraph(children=2, position=Position(lines=[1:1]))
+  - 2
+- - Strong(children=1)
+  - Paragraph(children=2, position=Position(lines=[1:1]))
+  - 2
+- - RawText()
+  - Paragraph(children=2, position=Position(lines=[3:3]))
+  - 2
+- - Link(target='link', title='')
+  - Paragraph(children=2, position=Position(lines=[3:3]))
+  - 2
+- - RawText()
+  - Strong(children=1)
+  - 3
+- - Emphasis(children=1)
+  - Link(target='link', title='')
+  - 3
+- - RawText()
+  - Emphasis(children=1)
+  - 4


### PR DESCRIPTION
This PR introduces footnote syntax to close #98. It also partially addresses #113 and #116 

The actual `Footnote` and `FootnoteReference` markdown tokens are implemented upstream in `mistletoe-ebp`:

- https://mistletoe-ebp.readthedocs.io/en/latest/api/extension_tokens.html#footnote
- https://mistletoe-ebp.readthedocs.io/en/latest/api/extension_tokens.html#footreference

**Important**: As the new documentation notes, this syntax currently only supports single line footnote definitions. Multiline footnote definitions will be addressed in a later PR.

For the docutils rendering, In my test I noted that, for rST, docutils/sphinx actually seems to handle these pretty poorly;

- not auto-collecting them into a single section at the bottom of the page,
- not making sure the numbers are ordered, by order of reference
- not discarding unreferenced footnotes

In the [sphinx doc](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#footnotes), they suggest putting them under a header. But I don't see that being an intuitive approach to footnotes.

Therefore, I have 'fixed' all these issues, as you can see in the test example.

[tests/test_sphinx/sourcedirs/footnotes/footnote_rst.rst](https://github.com/ExecutableBookProject/MyST-Parser/blob/add-footnote/tests/test_sphinx/sourcedirs/footnotes/footnote_rst.rst):

<img width="200" alt="image" src="https://user-images.githubusercontent.com/2997570/76370534-111dcd80-632f-11ea-933c-8d8adbab48ac.png">

[tests/test_sphinx/sourcedirs/footnotes/footnote_md.md](https://github.com/ExecutableBookProject/MyST-Parser/blob/add-footnote/tests/test_sphinx/sourcedirs/footnotes/footnote_md.md):

<img width="200" alt="image" src="https://user-images.githubusercontent.com/2997570/76370545-1aa73580-632f-11ea-822a-af3996d81620.png">

New user documentation of the syntax is here:
https://272-240151150-gh.circle-artifacts.com/0/html/using/syntax.html#footnotes,
and I also improved other aspects of it; turning the syntax lists into tables: https://272-240151150-gh.circle-artifacts.com/0/html/using/syntax.html#block-tokens (I'm sure @choldgraf will appreciate 😄)

@mmcky @rossbar @najuzilu @akhmerov have a look at the above documentation and see what you think!