### PR TITLE
DOC: Minor edits/suggestions from a full runthrough of documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
             - cache-pip
       - run: |
           pip install --user -e .[sphinx,rtd]
-          pip install -r docs/requirements.txt
       - save_cache:
           key: cache-pip
           paths:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,3 @@ python:
         extra_requirements:
           - sphinx
           - rtd
-      - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pandas_sphinx_theme"
+html_theme = "pydata_sphinx_theme"
 html_logo = "_static/logo.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/develop/test_infrastructure.md
+++ b/docs/develop/test_infrastructure.md
@@ -13,7 +13,7 @@ The tests are run using [pytest](https://docs.pytest.org)/[TravisCI](https://tra
 The tests are ordered in a hierarchical fashion:
 
 1. In `tests/test_syntax` are tests that check that the source text is being correctly converted to the Markdown ([mistletoe](https://github.com/miyuchina/mistletoe)) AST.
-2. In `tests/test_commonmark` the [CommonMark](https://github.com/commonmark/CommonMark.git) test set is run; to check that the parser is complying with the CommonMark specification.
+2. In `tests/test_commonmark` the [CommonMark](https://github.com/commonmark/CommonMark.git) test set is run to check that the parser is complying with the CommonMark specification.
 3. In `tests/test_renderers` are tests that check that the Markdown AST is being correctly converted to the docutils/sphinx AST. This includes testing that roles and directives are correctly parsed and run.
 4. In `tests/test_sphinx` are tests that check that minimal sphinx project builds are running correctly, to convert MyST markdown files to HTML.
 5. In `.circleci` the package documentation (written in MyST format) is built and tested for build errors/warnings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ MyST syntax and {doc}`Sphinx <sphinx:intro>`. This allows for native markdown su
 directives.
 
 ```{warning}
-The MyST parser is in an alpha stage, and may have breaking syntax to its implementation
+The MyST parser is in an alpha stage, and may have breaking changes to its implementation
 and to the syntax that it supports. Use at your own risk. If you find any issues,
 please report them
 [in the MyST issues](https://github.com/ExecutableBookProject/meta/issues/24)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master

--- a/docs/using/benchmark.md
+++ b/docs/using/benchmark.md
@@ -67,9 +67,9 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including [Setext] [1], [atx] [2], [Textile] [3], [reStructuredText] [4],
-[Grutatext] [5], and [EtText] [6] -- the single biggest source of
-inspiration for Markdown's syntax is the format of plain text email.
+filters -- including [Setext][1], [atx][2], [Textile][3], [reStructuredText][4],
+[Grutatext][5], and [EtText][6] -- the single biggest source of
+inspiration for Markdown's syntax is the format of plain-text email.
 
   [1]: http://docutils.sourceforge.net/mirror/setext.html
   [2]: http://www.aaronsw.com/2002/atx/
@@ -226,7 +226,7 @@ work best -- and look better -- when you format them with hard breaks.
 
 <h3 id="header">Headers</h3>
 
-Markdown supports two styles of headers, [Setext] [1] and [atx] [2].
+Markdown supports two styles of headers, [Setext][1] and [atx][2].
 
 Setext-style headers are "underlined" using equal signs (for first-level
 headers) and dashes (for second-level headers). For example:

--- a/docs/using/benchmark.md
+++ b/docs/using/benchmark.md
@@ -79,7 +79,7 @@ inspiration for Markdown's syntax is the format of plain-text email.
   [6]: http://ettext.taint.org/doc/
 
 To this end, Markdown's syntax is comprised entirely of punctuation
-characters, which punctuation characters have been carefully chosen so
+characters which have been carefully chosen so
 as to look like what they mean. E.g., asterisks around a word actually
 look like \*emphasis\*. Markdown lists look like, well, lists. Even
 blockquotes look like quoted passages of text, assuming you've ever

--- a/docs/using/benchmark.md
+++ b/docs/using/benchmark.md
@@ -237,8 +237,8 @@ headers) and dashes (for second-level headers). For example:
     This is an H2
     -------------
 
-This is an H2
--------------
+% This is an H2
+% -------------
 
 Any number of underlining `=`'s or `-`'s will work.
 

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -458,7 +458,7 @@ print('yep!')
 ## Roles - an in-line extension point
 
 Roles are similar to directives - they allow you to define arbitrary new
-functionality in Sphinx, but they are use *in-line*. To define an in-line
+functionality in Sphinx, but they are used *in-line*. To define an in-line
 role, use the following form:
 
 ````{list-table}
@@ -592,8 +592,8 @@ This is equivalent to the following directive:
 ### Front Matter
 
 This is a YAML block at the start of the document, as used for example in
-[jekyll](https://jekyllrb.com/docs/front-matter/). Sphinx intercepts this data and
-stores it within the global environment (as discussed
+[jekyll](https://jekyllrb.com/docs/front-matter/). Sphinx intercepts these data and
+stores them within the global environment (as discussed
 [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html)).
 
 A classic use-case is to specify 'orphan' documents, that are not specified in any
@@ -626,7 +626,7 @@ Is below, but it won't be parsed into the document.
 % my comment
 
 ````{important}
-Since comments are a block level entity, they will terminate the previous block.
+Since comments are a block-level entity, they will terminate the previous block.
 In practical terms, this means that the following lines
 will be broken up into two paragraphs, resulting in a new line between them:
 
@@ -756,7 +756,7 @@ indented by four or more spaces, will also be included in the footnote definitio
 
     That continues for all indented lines
 
-    Plus any precding unindented lines,
+    Plus any preceding unindented lines,
 that are not separated by a blank line
 
 This is not part of the footnote.

--- a/docs/using/use_api.md
+++ b/docs/using/use_api.md
@@ -289,10 +289,10 @@ print(document.pformat())
 
 ## Sphinx Renderer
 
-The `myst_parser.docutils_renderer.SphinxRenderer` builds on the `DocutilsRenderer` to add sphinx specific nodes, e.g. for cross-referencing between documents.
+The `myst_parser.docutils_renderer.SphinxRenderer` builds on the `DocutilsRenderer` to add sphinx-specific nodes, e.g. for cross-referencing between documents.
 
 ```{note}
-To use sphinx specific roles and directives outside of a `sphinx-build`, they must first be loaded with the `load_sphinx_env=True` option.
+To use sphinx-specific roles and directives outside of a `sphinx-build`, they must first be loaded with the `load_sphinx_env=True` option.
 ```
 
 ````python

--- a/myst_parser/block_tokens.py
+++ b/myst_parser/block_tokens.py
@@ -72,8 +72,8 @@ class LineComment(block_tokens.BlockToken):
 class BlockBreak(block_tokens.BlockToken):
     """Block break token ``+++``.
 
-    This syntax is myst specific, used to denote the start of a new block of text.
-    This constuct's intended use case is for mapping to cell based document formats,
+    This myst-specific syntax is used to denote the start of a new block of text.
+    This construct's intended use-case is for mapping to cell-based document formats,
     like jupyter notebooks, to indicate a new text cell.
     """
 

--- a/myst_parser/html_renderer.py
+++ b/myst_parser/html_renderer.py
@@ -9,7 +9,7 @@ from myst_parser.span_tokens import Role, Target
 
 
 class HTMLRenderer(html_renderer.HTMLRenderer):
-    """This HTML render uses the uses the MyST spec block and span tokens.
+    """This HTML renderer uses the uses the MyST spec block and span tokens.
 
     It is used to test compliance with the commonmark spec,
     and can be used for basic previews,

--- a/myst_parser/json_renderer.py
+++ b/myst_parser/json_renderer.py
@@ -7,7 +7,7 @@ from myst_parser.span_tokens import Role, Target
 
 
 class JsonRenderer(json.JsonRenderer):
-    """This JSON render uses the MyST spec block and span tokens.
+    """This JSON renderer uses the MyST spec block and span tokens.
     """
 
     default_block_tokens = (

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "pytest-regressions",
             "beautifulsoup4",
         ],
-        "rtd": ["sphinxcontrib-bibtex", "ipython"],
+        "rtd": ["sphinxcontrib-bibtex", "ipython", "pydata-sphinx-theme"],
     },
     zip_safe=True,
 )


### PR DESCRIPTION
In preparation for another round of converting Elegant Scipy chapters to MyST-flavored markdown, I did a full read-through of the documentation to get caught up on the latest changes/features.

While working my way through the docs (which are really great BTW), I made a couple minor changes mostly of a grammatical nature.

One set of non-grammatical changes that deserve special attention are those in ff7d040. [According to the docs](https://myst-parser.readthedocs.io/en/latest/using/benchmark.html#link), it should be allowed to have a space between bracketed reference links in markdown syntax, i.e. `[name] [key]` is equally as valid as `[name][key]`; however, this does not appear to work as expected (or at least not according to my interpretation of the docs). I've never used that syntax with markdown before, so I don't know if this is a MyST issue or a documentation issue - I just thought I'd draw extra attention to it.

In addition to the changes, I had a few comments additional comments:
 - The intersphinx links in `using/syntax.md` don't appear to have worked on the [deployed docs](https://myst-parser.readthedocs.io/en/latest/using/syntax.html). They work when building locally though, so maybe the version deployed to readthedocs needs to be updated.
 - The `using/benchmark.md` could maybe be titled differently or split into two separate pages. There is a brief section at the top of the page that discusses benchmarking/performance, followed by a much longer chunk of unrelated-ish text presenting an overview of markdown. From an organizational standpoint it might be nice to have an "Overview of markdown" page and a separate "Performance" page.
 - This may need to be a separate issue, but it seems like the [blockquotes are not currently working](https://myst-parser.readthedocs.io/en/latest/using/benchmark.html#blockquote). I see the same behavior when building locally (with 21d7e1e). I'm happy to open an issue to provide more detail.