### PR TITLE
Add paragraph wrapper to table rows

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -534,7 +534,7 @@ class DocutilsRenderer:
                     entry["classes"].append(style)
                 with self.current_node_context(entry, append=True):
                     with self.current_node_context(para, append=True):
-                            self.render_children(child)
+                        self.render_children(child)
 
     def render_math_inline(self, token):
         content = token.content

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -528,11 +528,13 @@ class DocutilsRenderer:
         with self.current_node_context(row, append=True):
             for child in token.children:
                 entry = nodes.entry()
+                para = nodes.paragraph("")
                 style = child.attrGet("style")  # i.e. the alignment when using e.g. :--
                 if style:
                     entry["classes"].append(style)
                 with self.current_node_context(entry, append=True):
-                    self.render_children(child)
+                    with self.current_node_context(para, append=True):
+                            self.render_children(child)
 
     def render_math_inline(self, token):
         content = token.content

--- a/tests/test_renderers/fixtures/sphinx_directives.md
+++ b/tests/test_renderers/fixtures/sphinx_directives.md
@@ -285,15 +285,19 @@ table (`sphinx.directives.patches.RSTTable`):
             <thead>
                 <row>
                     <entry>
-                        a
+                        <paragraph>
+                            a
                     <entry>
-                        b
+                        <paragraph>
+                            b
             <tbody>
                 <row>
                     <entry>
-                        1
+                        <paragraph>
+                            1
                     <entry>
-                        2
+                        <paragraph>
+                            2
 .
 
 --------------------------------

--- a/tests/test_renderers/fixtures/tables.md
+++ b/tests/test_renderers/fixtures/tables.md
@@ -13,15 +13,19 @@ a|b
             <thead>
                 <row>
                     <entry>
-                        a
+                        <paragraph>
+                            a
                     <entry>
-                        b
+                        <paragraph>
+                            b
             <tbody>
                 <row>
                     <entry>
-                        1
+                        <paragraph>
+                            1
                     <entry>
-                        2
+                        <paragraph>
+                            2
 .
 
 --------------------------
@@ -40,19 +44,25 @@ a | b | c
             <thead>
                 <row>
                     <entry classes="text-align:left">
-                        a
+                        <paragraph>
+                            a
                     <entry classes="text-align:center">
-                        b
+                        <paragraph>
+                            b
                     <entry classes="text-align:right">
-                        c
+                        <paragraph>
+                            c
             <tbody>
                 <row>
                     <entry classes="text-align:left">
-                        1
+                        <paragraph>
+                            1
                     <entry classes="text-align:center">
-                        2
+                        <paragraph>
+                            2
                     <entry classes="text-align:right">
-                        3
+                        <paragraph>
+                            3
 .
 
 --------------------------
@@ -70,18 +80,22 @@ Nested syntax:
             <thead>
                 <row>
                     <entry>
-                        <emphasis>
-                            a
-                    <entry>
-                        <strong>
+                        <paragraph>
                             <emphasis>
-                                b
+                                a
+                    <entry>
+                        <paragraph>
+                            <strong>
+                                <emphasis>
+                                    b
             <tbody>
                 <row>
                     <entry>
-                        <math>
-                            1
+                        <paragraph>
+                            <math>
+                                1
                     <entry>
-                        <subscript>
-                            x
+                        <paragraph>
+                            <subscript>
+                                x
 .

--- a/tests/test_renderers/fixtures/tables.md
+++ b/tests/test_renderers/fixtures/tables.md
@@ -99,3 +99,35 @@ Nested syntax:
                             <subscript>
                                 x
 .
+
+--------------------------
+External links:
+.
+a|b
+|-|-|
+[link-a](https://www.google.com/)|[link-b](https://www.python.org/)
+.
+<document source="notset">
+    <table classes="colwidths-auto">
+        <tgroup cols="2">
+            <colspec colwidth="50.0">
+            <colspec colwidth="50.0">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            <reference refuri="https://www.google.com/">
+                                link-a
+                    <entry>
+                        <paragraph>
+                            <reference refuri="https://www.python.org/">
+                                link-b
+.

--- a/tests/test_sphinx/sourcedirs/basic/content.md
+++ b/tests/test_sphinx/sourcedirs/basic/content.md
@@ -43,6 +43,7 @@ $$c=2$$ (eq:label)
 | a   | b |
 |-----|--:|
 | *a* | 2 |
+| [link-a](https://google.com) | [link-b](https://python.org) |
 
 this
 is

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.html
@@ -130,6 +130,22 @@
         </p>
        </td>
       </tr>
+      <tr class="row-odd">
+       <td>
+        <p>
+         <a class="reference external" href="https://google.com">
+          link-a
+         </a>
+        </p>
+       </td>
+       <td class="text-align:right">
+        <p>
+         <a class="reference external" href="https://python.org">
+          link-b
+         </a>
+        </p>
+       </td>
+      </tr>
      </tbody>
     </table>
     <p>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.html
@@ -104,22 +104,30 @@
      <thead>
       <tr class="row-odd">
        <th class="head">
-        a
+        <p>
+         a
+        </p>
        </th>
        <th class="text-align:right head">
-        b
+        <p>
+         b
+        </p>
        </th>
       </tr>
      </thead>
      <tbody>
       <tr class="row-even">
        <td>
-        <em>
-         a
-        </em>
+        <p>
+         <em>
+          a
+         </em>
+        </p>
        </td>
        <td class="text-align:right">
-        2
+        <p>
+         2
+        </p>
        </td>
       </tr>
      </tbody>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.xml
@@ -56,16 +56,20 @@
                 <thead>
                     <row>
                         <entry>
-                            a
+                            <paragraph>
+                                a
                         <entry classes="text-align:right">
-                            b
+                            <paragraph>
+                                b
                 <tbody>
                     <row>
                         <entry>
-                            <emphasis>
-                                a
+                            <paragraph>
+                                <emphasis>
+                                    a
                         <entry classes="text-align:right">
-                            2
+                            <paragraph>
+                                2
         <paragraph>
             this
             

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.xml
@@ -70,6 +70,15 @@
                         <entry classes="text-align:right">
                             <paragraph>
                                 2
+                    <row>
+                        <entry>
+                            <paragraph>
+                                <reference refuri="https://google.com">
+                                    link-a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                <reference refuri="https://python.org">
+                                    link-b
         <paragraph>
             this
             


### PR DESCRIPTION
Closes #127 

I added a paragraph wrapper to `render_table_row`, and modified the existing tests to capture this wrapper. 

Let me know if a new test should be added to this PR, making sure urls inside the table are rendered as references, or something of the sort.